### PR TITLE
chore(cloudflare): add option to set persistence dir

### DIFF
--- a/.changeset/rich-foxes-deliver.md
+++ b/.changeset/rich-foxes-deliver.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/cloudflare': minor
+---
+
+Adds a new property `persistTo` which allows setting the directory for local state files when using Cloudflare runtime with `astro dev`. This is useful when you want to persist state between restarts of the dev server, for example when using KV, D1, R2 to store data.
+
+Additionally, updates the format of the `runtime` configuration and adds a warning when the deprecated format is used. The current format is now `runtime: { mode: 'off' | 'local', persistTo: string }`. See [runtime documentation](https://docs.astro.build/en/guides/integrations-guide/cloudflare/#runtime) for more information.

--- a/packages/cloudflare/.gitignore
+++ b/packages/cloudflare/.gitignore
@@ -1,3 +1,4 @@
 # Astro cloudflare directory mode creates a function directory
 functions
 .mf
+.wrangler

--- a/packages/cloudflare/README.md
+++ b/packages/cloudflare/README.md
@@ -186,16 +186,24 @@ export default defineConfig({
 
 ### `runtime`
 
-`runtime: "off" | "local"`
+`runtime: { mode: "off" | "local", persistTo: string }`
 
-default `"off"`
+default `{ mode: 'off', persistTo: '' }`
 
 Determines whether and how the Cloudflare Runtime is added to `astro dev`.
 
 The Cloudflare Runtime includes [Cloudflare bindings](https://developers.cloudflare.com/pages/platform/functions/bindings), [environment variables](https://developers.cloudflare.com/pages/platform/functions/bindings/#environment-variables), and the [cf object](https://developers.cloudflare.com/workers/runtime-apis/request/#incomingrequestcfproperties). Read more about [accessing the Cloudflare Runtime](#cloudflare-runtime).
 
+The `mode` property defines how the runtime is added to `astro dev`:
+
 - `local`: uses bindings mocking and locally static placeholders
 - `off`: no access to the Cloudflare runtime using `astro dev`. You can alternatively use [Preview with Wrangler](#preview-with-wrangler)
+
+The `persistTo` property defines where the local runtime is persisted to when using `mode: local`. This value is a directory relative to your `astro dev` execution path.
+
+The default value is set to `.wrangler/state/v3` to match the default path Wrangler uses. This means both tools are able to access and use the local state.
+
+Whichever directory is set in `persistTo`, `.wrangler` or your custom value, must be added to `.gitignore`.
 
 ```diff lang="js"
 // astro.config.mjs
@@ -205,7 +213,7 @@ import cloudflare from '@astrojs/cloudflare';
 export default defineConfig({
   output: 'server',
   adapter: cloudflare({
-+   runtime: 'local',
++   runtime: { mode: 'local' },
   }),
 });
 ```

--- a/packages/cloudflare/test/fixtures/dev-runtime/astro.config.mjs
+++ b/packages/cloudflare/test/fixtures/dev-runtime/astro.config.mjs
@@ -1,10 +1,11 @@
 import { defineConfig } from 'astro/config';
 import cloudflare from '@astrojs/cloudflare';
 
-
 export default defineConfig({
 	adapter: cloudflare({
-		runtime: 'local'
+		runtime: {
+			mode: 'local',
+		},
 	}),
 	output: 'server',
 });

--- a/packages/cloudflare/test/fixtures/dev-runtime/package.json
+++ b/packages/cloudflare/test/fixtures/dev-runtime/package.json
@@ -5,5 +5,8 @@
   "dependencies": {
     "@astrojs/cloudflare": "workspace:*",
     "astro": "^3.2.3"
+  },
+  "devDependencies": {
+    "wrangler": "^3.13.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,10 @@ importers:
       astro:
         specifier: ^3.2.3
         version: 3.3.0(@types/node@18.17.8)(typescript@5.1.6)
+    devDependencies:
+      wrangler:
+        specifier: ^3.13.1
+        version: 3.13.1
 
   packages/cloudflare/test/fixtures/directory-mode:
     dependencies:
@@ -1125,7 +1129,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@cloudflare/workerd-darwin-arm64@1.20231002.0:
@@ -1143,7 +1146,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@cloudflare/workerd-linux-64@1.20231002.0:
@@ -1161,7 +1163,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@cloudflare/workerd-linux-arm64@1.20231002.0:
@@ -1179,7 +1180,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@cloudflare/workerd-windows-64@1.20231002.0:
@@ -1197,7 +1197,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@cloudflare/workers-types@4.20230821.0:
@@ -5610,7 +5609,6 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
-    dev: false
 
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -7869,7 +7867,6 @@ packages:
       '@cloudflare/workerd-linux-64': 1.20231010.0
       '@cloudflare/workerd-linux-arm64': 1.20231010.0
       '@cloudflare/workerd-windows-64': 1.20231010.0
-    dev: false
 
   /workerpool@6.2.1:
     resolution: {integrity: sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==}
@@ -7887,6 +7884,32 @@ packages:
       chokidar: 3.5.3
       esbuild: 0.17.19
       miniflare: 3.20231002.1
+      nanoid: 3.3.6
+      path-to-regexp: 6.2.1
+      selfsigned: 2.1.1
+      source-map: 0.6.1
+      source-map-support: 0.5.21
+      xxhash-wasm: 1.0.2
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /wrangler@3.13.1:
+    resolution: {integrity: sha512-CY73h4lfPx/3CmkC/tPj66DRRZ9Y42sMcHys6B6tjCILUo950IeOvnsj759el3/ewFLY4kG4jCrrrikan6TE+Q==}
+    engines: {node: '>=16.13.0'}
+    hasBin: true
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.2.0
+      '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
+      '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
+      blake3-wasm: 2.1.5
+      chokidar: 3.5.3
+      esbuild: 0.17.19
+      miniflare: 3.20231010.0
       nanoid: 3.3.6
       path-to-regexp: 6.2.1
       selfsigned: 2.1.1


### PR DESCRIPTION
## Changes

- Fixes a DX issue with Cloudflare runtime in `astro dev`
- Now you should be able to use `wrangler` as you are used to, to seed db or apply migrations
- **Open question:** see code comments of self-review
- Don't forget a changeset! `pnpm exec changeset`

## Testing

- existing test
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

- cc @withastro/maintainers-docs 
<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
