### PR TITLE
chore: update CI/CD workflows

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -7,40 +7,9 @@ on:
       - main
 
 jobs:
-  format:
-    name: Format
+  prettier:
     if: github.repository_owner == 'withastro'
-    runs-on: ubuntu-latest
-    env:
-      NODE_OPTIONS: "--max_old_space_size=4096"
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
-          # Needs access to push to main
-          token: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v2
-      
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: "pnpm"
-      
-      - name: Install dependencies
-        run: pnpm install
-      
-      - name: Format code
-        run: pnpm run format:ci
-      
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: "[ci] format"
-          branch: ${{ github.head_ref }}
-          commit_user_name: astrobot-houston
-          commit_user_email: fred+astrobot@astro.build
+    uses: withastro/automation/.github/workflows/format.yml@main
+    with:
+      command: "format:ci"
+    secrets: inherit

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -1,0 +1,158 @@
+name: Create a Snapshot Release
+
+on:
+  workflow_dispatch:
+  issue_comment:
+    types: [created]
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  FORCE_COLOR: 1
+
+jobs:
+  snapshot-release:
+    name: Create a snapshot release of a pull request
+    if: ${{ github.repository_owner == 'withastro' && github.event.issue.pull_request && contains(fromJSON('["!preview", "/preview", "!snapshot", "/snapshot"]'), github.event.comment.body) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: "Check if user has admin access (only admins can publish snapshot releases)."
+        uses: "lannonbr/repo-permission-check-action@2.0.0"
+        with:
+          permission: "admin"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract the snapshot name from comment body
+        id: getSnapshotName
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { body } = context.payload.comment;
+            const PREVIEW_RE = /^[!\/](?:preview|snapshot)\s+(\S*)\s*$/gim;
+            const [_, name] = PREVIEW_RE.exec(body) ?? [];
+            if (name) return name;
+
+            const error = 'Invalid command. Expected: "/preview <snapshot-name>"'
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: error,
+            })
+            core.setFailed(error)
+          result-encoding: string
+
+      - name: resolve pr refs
+        id: refs
+        uses: eficode/resolve-pr-refs@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.refs.outputs.head_ref }}
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build Packages
+        run: pnpm run build
+
+      - name: Bump Package Versions
+        id: changesets
+        run: |
+          pnpm exec changeset status --output status.output.json 2>&1
+          pnpm exec changeset version --snapshot ${{ steps.getSnapshotName.outputs.result }}
+
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "status<<$EOF" >> $GITHUB_OUTPUT
+          echo "$(cat status.output.json)" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+        env:
+          # Needs access to run the script
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Disable color
+          FORCE_COLOR: 0
+          NO_COLOR: 1
+
+      - name: Publish Release
+        id: publish
+        run: |
+          GITHUB_ACTIONS=0 pnpm run build > build.output.txt 2>&1
+          pnpm exec changeset publish --tag experimental--${{ steps.getSnapshotName.outputs.result }} > publish.output.txt 2>&1
+
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+
+          echo "build<<$EOF" >> $GITHUB_OUTPUT
+          echo "$(cat build.output.txt)" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+          cat build.output.txt
+
+          echo "publish<<$EOF" >> $GITHUB_OUTPUT
+          echo "$(cat publish.output.txt)" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+          cat publish.output.txt
+        env:
+          # Needs access to publish to npm
+          NPM_TOKEN: ${{ secrets.CHANGESETS_RELEASE_PR_WORKFLOW_NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.CHANGESETS_RELEASE_PR_WORKFLOW_NPM_TOKEN }}
+          # Disable color
+          FORCE_COLOR: 0
+          NO_COLOR: 1
+
+      - name: Pull Request Notification
+        uses: actions/github-script@v6
+        env:
+          TAG: ${{ steps.getSnapshotName.outputs.result }}
+          STATUS_DATA: ${{ steps.changesets.outputs.status }}
+          BUILD_LOG: ${{ steps.publish.outputs.build }}
+          PUBLISH_LOG: ${{ steps.publish.outputs.publish }}
+        with:
+          script: |
+            let changeset = { releases: [] };
+            try {
+              changeset = JSON.parse(process.env.STATUS_DATA);
+            } catch (e) {}
+            let message = 'Snapshots have been released for the following packages:'
+            for (const release of changeset.releases) {
+              if (release.type === 'none') continue;
+              message += `\n- \`${release.name}@experimental--${process.env.TAG}\``;
+            }
+
+            function details(title, body) {
+              message += '\n';
+              message += `<details><summary><strong>${title}</strong></summary>`
+              message += '\n\n```\n';
+              message += body;
+              message += '\n```\n\n</details>';
+            }
+
+            details('Publish Log', process.env.PUBLISH_LOG);
+            details('Build Log', process.env.BUILD_LOG);
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: message,
+            })


### PR DESCRIPTION
## Changes

- use shared `format` workflow
- ported `preview` workflow, due to different secret names