### PR TITLE
Fix incorrect netlify redirect test

### DIFF
--- a/packages/netlify/test/functions/redirects.test.js
+++ b/packages/netlify/test/functions/redirects.test.js
@@ -40,11 +40,12 @@ describe('SSG - Redirects', () => {
 	});
 
 	it('Does not create .html files', async () => {
+		let hasErrored = false;
 		try {
 			await fixture.readFile('/other/index.html');
-			expect(false).to.equal(true, 'this file should not exist');
 		} catch {
-			expect(true).to.equal(true);
+			hasErrored = true;
 		}
+		expect(hasErrored).to.equal(true, 'this file should not exist');
 	});
 });


### PR DESCRIPTION
## Changes

Fix incorrect assertion. Inside the try block, the assertion is intentionally failing to fail the test, however because it's still within the try block, the catch block will turn it back to passing, which is incorrect.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Ran the tests manually. Found this while working on https://github.com/withastro/astro/issues/7889

## Docs

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
n/a