### PR TITLE
fix(cloudflare): allow compile-time image optimization for prerendered pages

### DIFF
--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -112,7 +112,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					config.image.service.entrypoint === 'astro/assets/services/squoosh'
 				) {
 					logger.warn(
-						`The current configuration does not support image optimization. To allow your project to build with the original, unoptimized images, the image service has been automatically switched to the 'noop' option. See https://docs.astro.build/en/reference/configuration-reference/#imageservice`
+						`The current configuration does not support image optimization using SSR on edge. To allow your project to build with the original, unoptimized images, the image service has been automatically switched to the 'noop' option. See https://docs.astro.build/en/reference/configuration-reference/#imageservice`
 					);
 					imageConfigOverwrite = true;
 				}
@@ -133,7 +133,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 						],
 					},
 					image: imageConfigOverwrite
-						? { ...config.image, service: passthroughImageService() }
+						? { ...config.image, endpoint: '/null' }
 						: config.image,
 				});
 			},

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -133,7 +133,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 						],
 					},
 					image: imageConfigOverwrite
-						? { ...config.image, endpoint: '/null' }
+						? { ...config.image, endpoint: import.meta.env.DEV ? undefined : '/null' }
 						: config.image,
 				});
 			},


### PR DESCRIPTION
## Changes

TLDR of the issue: the driver currently unnecessarily blocks image optimization even if it could be used just fine on static pages. The only issue is with including the image services in the SSR bundle.

I was more or less trying to reimplement the solution [discussed on Discord](https://discord.com/channels/830184174198718474/830184175176122389/1170827297452998738) but realized we don't actually need to re-export the services here, since the entire point of that was bypassing the if check in this code I believe.

So the only change now is adding an endpoint.

TODOs:
- [ ] Implement the endpoint so that it points to an existing file
- [ ] Not sure how this will work with SSR? We want to use the noop driver on SSR `<Image>` tags. Maybe the endpoint can handle that? Otherwise we could maybe specify the *entry*point conditionally, i.e. something like this (I think?)
    ```js
    service: import.meta.env.DEV ? config.image.service : passthroughImageService()
    ```

@alexanderniebuhr 

## Testing

## Docs

