### PR TITLE
fix(cloudflare): Fix `404.astro` not being used when `routes.strategy` is set to `exclude`

### DIFF
--- a/.changeset/twelve-grapes-dream.md
+++ b/.changeset/twelve-grapes-dream.md
@@ -2,4 +2,4 @@
 '@astrojs/cloudflare': patch
 ---
 
-Fix 404 responses in "exclude" routing strategy
+Fixes an issue where `404.astro` was not used when `routes.strategy` was set to `exclude`

--- a/.changeset/twelve-grapes-dream.md
+++ b/.changeset/twelve-grapes-dream.md
@@ -2,4 +2,4 @@
 '@astrojs/cloudflare': patch
 ---
 
-Fixes a regression which caused the adapter to falsely return an empty 404 response, caused by a change in `app.match()` behavior, which was introduced in https://github.com/withastro/astro/pull/7754. We forget to update the Cloudflare adapter and this implements the necessary fix.
+Fixes a regression which caused the adapter to falsely return an empty 404 response, caused by an upstream change https://github.com/withastro/astro/pull/7754.

--- a/.changeset/twelve-grapes-dream.md
+++ b/.changeset/twelve-grapes-dream.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': minor
+---
+
+Fix 404 responses in "exclude" routing strategy

--- a/.changeset/twelve-grapes-dream.md
+++ b/.changeset/twelve-grapes-dream.md
@@ -1,5 +1,5 @@
 ---
-'@astrojs/cloudflare': minor
+'@astrojs/cloudflare': patch
 ---
 
 Fix 404 responses in "exclude" routing strategy

--- a/.changeset/twelve-grapes-dream.md
+++ b/.changeset/twelve-grapes-dream.md
@@ -2,4 +2,4 @@
 '@astrojs/cloudflare': patch
 ---
 
-Fixes an issue where `404.astro` was not used when `routes.strategy` was set to `exclude`
+Fixes a regression which caused the adapter to falsely return an empty 404 response, caused by a change in `app.match()` behavior, which was introduced in https://github.com/withastro/astro/pull/7754. We forget to update the Cloudflare adapter and this implements the necessary fix.

--- a/packages/cloudflare/src/entrypoints/server.advanced.ts
+++ b/packages/cloudflare/src/entrypoints/server.advanced.ts
@@ -39,35 +39,33 @@ export function createExports(manifest: SSRManifest) {
 			return env.ASSETS.fetch(request);
 		}
 
-		// REF: If routeData is undefined, the render method invokes the #renderError method
-		let routeData = app.match(request, { matchNotFound: true }) || undefined;
+		let routeData = app.match(request, { matchNotFound: true });
+			Reflect.set(
+				request,
+				Symbol.for('astro.clientAddress'),
+				request.headers.get('cf-connecting-ip')
+			);
 
-		Reflect.set(
-			request,
-			Symbol.for('astro.clientAddress'),
-			request.headers.get('cf-connecting-ip')
-		);
-
-		const locals: AdvancedRuntime = {
-			runtime: {
-				waitUntil: (promise: Promise<any>) => {
-					context.waitUntil(promise);
+			const locals: AdvancedRuntime = {
+				runtime: {
+					waitUntil: (promise: Promise<any>) => {
+						context.waitUntil(promise);
+					},
+					env: env,
+					cf: request.cf,
+					caches: caches as unknown as CacheStorage,
 				},
-				env: env,
-				cf: request.cf,
-				caches: caches as unknown as CacheStorage,
-			},
-		};
+			};
 
-		let response = await app.render(request, routeData, locals);
+			let response = await app.render(request, routeData, locals);
 
-		if (app.setCookieHeaders) {
-			for (const setCookieHeader of app.setCookieHeaders(response)) {
-				response.headers.append('Set-Cookie', setCookieHeader);
+			if (app.setCookieHeaders) {
+				for (const setCookieHeader of app.setCookieHeaders(response)) {
+					response.headers.append('Set-Cookie', setCookieHeader);
+				}
 			}
-		}
 
-		return response;
+			return response;
 	};
 
 	return { default: { fetch } };

--- a/packages/cloudflare/src/entrypoints/server.advanced.ts
+++ b/packages/cloudflare/src/entrypoints/server.advanced.ts
@@ -39,7 +39,7 @@ export function createExports(manifest: SSRManifest) {
 			return env.ASSETS.fetch(request);
 		}
 
-		let routeData = app.match(request, { matchNotFound: true });
+		let routeData = app.match(request);
 			Reflect.set(
 				request,
 				Symbol.for('astro.clientAddress'),

--- a/packages/cloudflare/src/entrypoints/server.directory.ts
+++ b/packages/cloudflare/src/entrypoints/server.directory.ts
@@ -32,40 +32,35 @@ export function createExports(manifest: SSRManifest) {
 			return env.ASSETS.fetch(request);
 		}
 
-		let routeData = app.match(request, { matchNotFound: true });
-		if (routeData) {
-			Reflect.set(
-				request,
-				Symbol.for('astro.clientAddress'),
-				request.headers.get('cf-connecting-ip')
-			);
+		// REF: If routeData is undefined, the render method invokes the #renderError method
+		let routeData = app.match(request, { matchNotFound: true }) || undefined;
 
-			const locals: DirectoryRuntime = {
-				runtime: {
-					waitUntil: (promise: Promise<any>) => {
-						context.waitUntil(promise);
-					},
-					env: context.env,
-					cf: request.cf,
-					caches: caches as unknown as CacheStorage,
+		Reflect.set(
+			request,
+			Symbol.for('astro.clientAddress'),
+			request.headers.get('cf-connecting-ip')
+		);
+
+		const locals: DirectoryRuntime = {
+			runtime: {
+				waitUntil: (promise: Promise<any>) => {
+					context.waitUntil(promise);
 				},
-			};
+				env: context.env,
+				cf: request.cf,
+				caches: caches as unknown as CacheStorage,
+			},
+		};
 
-			let response = await app.render(request, routeData, locals);
+		let response = await app.render(request, routeData, locals);
 
-			if (app.setCookieHeaders) {
-				for (const setCookieHeader of app.setCookieHeaders(response)) {
-					response.headers.append('Set-Cookie', setCookieHeader);
-				}
+		if (app.setCookieHeaders) {
+			for (const setCookieHeader of app.setCookieHeaders(response)) {
+				response.headers.append('Set-Cookie', setCookieHeader);
 			}
-
-			return response;
 		}
 
-		return new Response(null, {
-			status: 404,
-			statusText: 'Not found',
-		});
+		return response;
 	};
 
 	return { onRequest, manifest };

--- a/packages/cloudflare/src/entrypoints/server.directory.ts
+++ b/packages/cloudflare/src/entrypoints/server.directory.ts
@@ -32,7 +32,7 @@ export function createExports(manifest: SSRManifest) {
 			return env.ASSETS.fetch(request);
 		}
 
-		let routeData = app.match(request, { matchNotFound: true });
+		let routeData = app.match(request);
 			Reflect.set(
 				request,
 				Symbol.for('astro.clientAddress'),


### PR DESCRIPTION
## Changes

Turns out it was an adapter issue after all! Fixes withastro/adapters#67

Currently, missing routes in the Cloudflare adapter are responded to with blank 404 responses:
```js
return new Response(null, {
	status: 404,
	statusText: 'Not found',
});
```
Astro has its own error handler! We can use that by returning `undefined` for our `routeData` in our render function. This pr does that.

## Testing

By using `pnpm link` in the [latest](https://github.com/ToxiWoxi/astro-404-issue/tree/latest) branch of my 404 issue repo and going to `http://localhost:8788/thispagedoesnotexist` in my browser, I can confirm that these changes result in the #renderError method being invoked which allows 404 pages being rendered properly whether they're prerendered or server-rendered.

I've also set up 3 previews:
One that uses a [server-rendered 404 page](https://astro-404-ssr.pages.dev), another that uses a [prerendered 404 page](https://astro-404-prerendered.pages.dev), and a third that shows the [current behavior](https://latest.astro-404-issue.pages.dev).

## Docs

I don't recommend any changes to the docs.  
This PR should not change the behavior of any users as it returns 404 behavior back to normal, matching other adapters.  

## Issues
The current #renderError method in the main repo fetches the 404 page when the 404 page is prerendered. This is seen in a warning in Wrangler. It does not effect website visitors, but it does result in 2 subrequests per page load, which you can see in the `Functions metrics` on the Cloudflare dashboard. To avoid this, you can use the "include" routing strategy or use SSR on the 404 page.  
I may open an issue for this in the main Astro repo later.