### PR TITLE
fix(cloudflare): routing strategy doesn't support on-demand 404

### DIFF
--- a/.changeset/spotty-kings-roll.md
+++ b/.changeset/spotty-kings-roll.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes a regression which caused the adapter to falsely generate `_routes.json` for on-demand rendered 404 pages, which causes unexpected behavior in Cloudflare's SPA routing.


### PR DESCRIPTION
## Changes

- always use `exclude` strategy for `auto`, to make sure routing works as expected on Cloudflare's SPA mode
- closes https://github.com/withastro/adapters/issues/64