### PR TITLE
chore: remove `type EndpointOutput`

### DIFF
--- a/.changeset/violet-zoos-push.md
+++ b/.changeset/violet-zoos-push.md
@@ -1,6 +1,0 @@
----
-'@astrojs/cloudflare': patch
----
-
-Remove `type EndpointOutput` following withastro/astro PR: Remove support for simple objects in endpoints (#9181) in https://github.com/withastro/astro/commit/cdabf6ef02be7220fd2b6bdcef924ceca089381e#diff-cec1de65bb8dd2f8330cb37fe3698afd66162bc0f311aa11e0b3dd573f6a2b9f
-

--- a/.changeset/violet-zoos-push.md
+++ b/.changeset/violet-zoos-push.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Remove `type EndpointOutput` following withastro/astro PR: Remove support for simple objects in endpoints (#9181) in https://github.com/withastro/astro/commit/cdabf6ef02be7220fd2b6bdcef924ceca089381e#diff-cec1de65bb8dd2f8330cb37fe3698afd66162bc0f311aa11e0b3dd573f6a2b9f
+

--- a/packages/cloudflare/test/fixtures/wasm-directory/src/pages/index.ts
+++ b/packages/cloudflare/test/fixtures/wasm-directory/src/pages/index.ts
@@ -1,4 +1,4 @@
-import { type APIContext, type EndpointOutput } from 'astro';
+import { type APIContext } from 'astro';
 // @ts-ignore
 import mod from '../util/add.wasm?module';
 
@@ -7,7 +7,7 @@ const addModule: any = new WebAssembly.Instance(mod);
 
 export async function GET(
   context: APIContext
-): Promise<EndpointOutput | Response> {
+): Promise<Response> {
 
   return new Response(JSON.stringify({ answer: addModule.exports.add(40, 2) }), {
     status: 200,

--- a/packages/cloudflare/test/fixtures/wasm-function-per-route/src/pages/deeply/nested/route.ts
+++ b/packages/cloudflare/test/fixtures/wasm-function-per-route/src/pages/deeply/nested/route.ts
@@ -1,9 +1,9 @@
-import { type APIContext, type EndpointOutput } from 'astro';
+import { type APIContext } from 'astro';
 import { add } from '../../../util/add';
 
 export async function GET(
   context: APIContext
-): Promise<EndpointOutput | Response> {
+): Promise<Response> {
 
   return new Response(JSON.stringify({ answer: add(80, 4) }), {
     status: 200,

--- a/packages/cloudflare/test/fixtures/wasm-function-per-route/src/pages/index.ts
+++ b/packages/cloudflare/test/fixtures/wasm-function-per-route/src/pages/index.ts
@@ -1,9 +1,9 @@
-import { type APIContext, type EndpointOutput } from 'astro';
+import { type APIContext } from 'astro';
 import { add } from '../util/add';
 
 export async function GET(
   context: APIContext
-): Promise<EndpointOutput | Response> {
+): Promise<Response> {
 
   return new Response(JSON.stringify({ answer: add(40, 2) }), {
     status: 200,

--- a/packages/cloudflare/test/fixtures/wasm/src/pages/add/[a]/[b].ts
+++ b/packages/cloudflare/test/fixtures/wasm/src/pages/add/[a]/[b].ts
@@ -1,4 +1,4 @@
-import { type APIContext, type EndpointOutput } from 'astro';
+import { type APIContext } from 'astro';
 // @ts-ignore
 import mod from '../../../util/add.wasm?module';
 
@@ -8,7 +8,7 @@ export const prerender = false;
 
 export async function GET(
   context: APIContext
-): Promise<EndpointOutput | Response> {
+): Promise<Response> {
 	const a = Number.parseInt(context.params.a!);
 	const b = Number.parseInt(context.params.b!);
   return new Response(JSON.stringify({ answer: addModule.exports.add(a, b) }), {

--- a/packages/cloudflare/test/fixtures/wasm/src/pages/hybrid.ts
+++ b/packages/cloudflare/test/fixtures/wasm/src/pages/hybrid.ts
@@ -1,4 +1,4 @@
-import { type APIContext, type EndpointOutput } from 'astro';
+import { type APIContext } from 'astro';
 // @ts-ignore
 import mod from '../util/add.wasm?module';
 
@@ -6,7 +6,7 @@ const addModule: any = new WebAssembly.Instance(mod);
 
 export async function GET(
   context: APIContext
-): Promise<EndpointOutput | Response> {
+): Promise<Response> {
   return new Response(JSON.stringify({ answer: addModule.exports.add(20, 1) }), {
     status: 200,
     headers: {


### PR DESCRIPTION
I notice this when playing with Astro v4.0.0-beta.4. I think this should only be an issue when Astro 4 is in. But as of now the tests still passes. I'd say it's to push this along when updating tests to Astro v4. I'll leave as a draft PR for reference.


This only happens when a test fixture is updated to v4
<img src="https://github.com/withastro/adapters/assets/61759797/69b6c353-6fcf-4cbf-89c1-1b24549d7e87" width="60%"/>


- More context on https://github.com/withastro/adapters/issues/76#issuecomment-1837365310

Now, I'm unsure just removing it is the solution. This change is based on the mentioned upstream Astro PR and from it, it seems that just removing is fine.

## Changes
- Removed `type EndpointOutput`
## Testing

`pnpm test` on Windows.
![image](https://github.com/withastro/adapters/assets/61759797/245cdf18-722e-48ed-a962-7f2396884a23)

<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

It should not affect users
<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
---
Thank you