### PR TITLE
chore(cloudflare): remove deprecated `build.split` option

### DIFF
--- a/.changeset/breezy-rings-invite.md
+++ b/.changeset/breezy-rings-invite.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': major
+---
+
+Removes deprecated option `build.split`. Use `functionPerRoute` instead.

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -194,8 +194,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					await fs.promises.mkdir(functionsUrl, { recursive: true });
 				}
 
-				// TODO: remove _buildConfig.split in Astro 4.0
-				if (isModeDirectory && (_buildConfig.split || functionPerRoute)) {
+				if (isModeDirectory && functionPerRoute) {
 					const entryPointsURL = [..._entryPoints.values()];
 					const entryPaths = entryPointsURL.map((entry) => fileURLToPath(entry));
 					const outputUrl = new URL('$astro', _buildConfig.server);


### PR DESCRIPTION
closes https://github.com/withastro/adapters/issues/76