### PR TITLE
Release @astrojs/netlify for astro 4

### DIFF
--- a/.changeset/gentle-mangos-fix.md
+++ b/.changeset/gentle-mangos-fix.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+Fixes an issue where this package could not be installed alongside Astro 4.0.

--- a/packages/netlify/test/functions/fixtures/base64-response/src/pages/font.js
+++ b/packages/netlify/test/functions/fixtures/base64-response/src/pages/font.js
@@ -1,5 +1,5 @@
 
-export function get() {
+export function GET() {
 	const buffer = Buffer.from('base64 test font', 'utf-8')
 
   return new Response(buffer, {

--- a/packages/netlify/test/functions/fixtures/base64-response/src/pages/image.js
+++ b/packages/netlify/test/functions/fixtures/base64-response/src/pages/image.js
@@ -1,5 +1,5 @@
 
-export function get() {
+export function GET() {
 	const buffer = Buffer.from('base64 test string', 'utf-8')
 
   return new Response(buffer, {

--- a/packages/netlify/test/functions/fixtures/cookies/src/pages/login.js
+++ b/packages/netlify/test/functions/fixtures/cookies/src/pages/login.js
@@ -1,5 +1,5 @@
 
-export function post() {
+export function POST() {
 	const headers = new Headers();
   headers.append('Set-Cookie', `foo=foo; HttpOnly`);
   headers.append('Set-Cookie', `bar=bar; HttpOnly`);


### PR DESCRIPTION
## Changes

- Changeset to cut a release (peer dependency is already updated)

## Testing

- Updated tests to remove deprecated endpoint casing

## Docs

Does not affect behavior
