### PR TITLE
fix: use fs read instead of JSON import

### DIFF
--- a/.changeset/fluffy-spoons-cheat.md
+++ b/.changeset/fluffy-spoons-cheat.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+fix crash when reading package.json version field

--- a/packages/netlify/src/index.ts
+++ b/packages/netlify/src/index.ts
@@ -5,8 +5,9 @@ import type { Context } from '@netlify/functions';
 import type { AstroConfig, AstroIntegration, RouteData } from 'astro';
 import { AstroError } from 'astro/errors';
 import { build } from 'esbuild';
-import { appendFile, mkdir, rm, writeFile } from 'fs/promises';
-import { version as packageVersion } from '../package.json';
+import { appendFile, mkdir, rm, writeFile, readFile } from 'fs/promises';
+
+const { version: packageVersion } = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'));
 
 export interface NetlifyLocals {
 	netlify: {


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/adapters/issues/104.

We were crashing when importing the adapter because importing JSON isn't supported on all versions of Node.js. This PR replaces it with `readFile` instead. We could've used import assertions instead, but then we'd also need to change some typescript settings which is risky.

## Testing

tested locally.

## Docs

no docs needed, it's a fix.