### PR TITLE
fix(netlify): only cache GET/HEAD methods

### DIFF
--- a/.changeset/dry-rules-bathe.md
+++ b/.changeset/dry-rules-bathe.md
@@ -2,4 +2,4 @@
 '@astrojs/netlify': patch
 ---
 
-Fixes cacheOnDemandPages setting to only cache GET/HEAD requests by default
+Updates the behavior of the `cacheOnDemandPages` setting to only cache GET/HEAD requests by default

--- a/.changeset/dry-rules-bathe.md
+++ b/.changeset/dry-rules-bathe.md
@@ -2,4 +2,4 @@
 '@astrojs/netlify': patch
 ---
 
-only cache GET/HEAD requests with cacheOnDemandPages
+Fixes cacheOnDemandPages setting to only cache GET/HEAD requests by default

--- a/.changeset/dry-rules-bathe.md
+++ b/.changeset/dry-rules-bathe.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+only cache GET/HEAD requests with cacheOnDemandPages

--- a/packages/netlify/src/ssr-function.ts
+++ b/packages/netlify/src/ssr-function.ts
@@ -36,6 +36,8 @@ export const createExports = (manifest: SSRManifest, _args: Args) => {
 			}
 
 			if (integrationConfig.cacheOnDemandPages) {
+				const isCacheableMethod = ['GET', 'HEAD'].includes(request.method);
+
 				// any user-provided Cache-Control headers take precedence
 				const hasCacheControl = [
 					'Cache-Control',
@@ -43,7 +45,7 @@ export const createExports = (manifest: SSRManifest, _args: Args) => {
 					'Netlify-CDN-Cache-Control',
 				].some((header) => response.headers.has(header));
 
-				if (!hasCacheControl) {
+				if (isCacheableMethod && !hasCacheControl) {
 					// caches this page for up to a year
 					response.headers.append('CDN-Cache-Control', 'public, max-age=31536000, must-revalidate');
 				}


### PR DESCRIPTION
## Changes

If `cacheOnDemandPages` is enabled, we're currently adding caching headers to all responses, including POST responses. Caching POST requests is unconventional, and shouldn't be done by default!

This PR makes it so the adapter only adds caching headers for GET and HEAD requests.

## Testing

No test added because there's no test for `cacheOnDemandPages` yet - let me know if I should add one.

## Docs

Don't think this needs docs.

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
