### PR TITLE
chore: add changeset for netlify

### DIFF
--- a/.changeset/seven-comics-act.md
+++ b/.changeset/seven-comics-act.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': major
+---
+
+Updates the internals of the integration to support Astro 4.0. See this [upstream pull request](https://github.com/withastro/astro/pull/9199) for additional details. **Warning:** Make sure to upgrade your Astro version to `>4.0` as previous versions are no longer supported.


### PR DESCRIPTION
## Changes

- adds the already approved changeset for netlify but with `4.0.0` instead of `4.2.0`
