### PR TITLE
chore: bump astro version

### DIFF
--- a/.changeset/curly-oranges-end.md
+++ b/.changeset/curly-oranges-end.md
@@ -1,5 +1,6 @@
 ---
 "@astrojs/cloudflare": major
+"@astrojs/netlify": major
 ---
 
 Updates the internals of the integration to support Astro 4.0. See this [upstream pull request](https://github.com/withastro/astro/pull/9199) for additional details. **Warning:** Make sure to upgrade your Astro version to `>4.2` as previous versions are no longer supported.

--- a/.changeset/seven-comics-act.md
+++ b/.changeset/seven-comics-act.md
@@ -1,5 +1,0 @@
----
-'@astrojs/netlify': major
----
-
-Updates the internals of the integration to support Astro 4.0. See this [upstream pull request](https://github.com/withastro/astro/pull/9199) for additional details. **Warning:** Make sure to upgrade your Astro version to `>4.0` as previous versions are no longer supported.

--- a/packages/netlify/package.json
+++ b/packages/netlify/package.json
@@ -41,13 +41,13 @@
     "esbuild": "^0.19.5"
   },
   "peerDependencies": {
-    "astro": "^4.0.0"
+    "astro": "^4.2.0"
   },
   "devDependencies": {
     "@netlify/edge-functions": "^2.0.0",
     "@netlify/edge-handler-types": "^0.34.1",
     "@types/node": "^18.17.8",
-    "astro": "^4.0.0",
+    "astro": "^4.2.0",
     "chai": "^4.3.10",
     "chai-jest-snapshot": "^2.0.0",
     "cheerio": "1.0.0-rc.12",

--- a/packages/netlify/test/hosted/hosted-astro-project/package.json
+++ b/packages/netlify/test/hosted/hosted-astro-project/package.json
@@ -7,6 +7,6 @@
   },
   "dependencies": {
     "@astrojs/netlify": "workspace:*",
-    "astro": "^4.0.0"
+    "astro": "^4.2.0"
   }
 }

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -8,7 +8,7 @@
   },
   "keywords": [],
   "dependencies": {
-    "astro": "^4.0.0",
+    "astro": "^4.2.0",
     "execa": "^8",
     "fast-glob": "^3",
     "strip-ansi": "^7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,7 +286,7 @@ importers:
         specifier: ^18.17.8
         version: 18.19.2
       astro:
-        specifier: ^4.0.0
+        specifier: ^4.2.0
         version: 4.2.0(@types/node@18.19.2)(typescript@5.3.2)
       chai:
         specifier: ^4.3.10
@@ -343,7 +343,7 @@ importers:
         specifier: workspace:*
         version: link:../../..
       astro:
-        specifier: ^4.0.0
+        specifier: ^4.2.0
         version: 4.2.0(@types/node@18.19.2)(typescript@5.3.2)
 
   packages/netlify/test/static/fixtures/redirects:
@@ -355,7 +355,7 @@ importers:
   packages/test-utils:
     dependencies:
       astro:
-        specifier: ^4.0.0
+        specifier: ^4.2.0
         version: 4.2.0(@types/node@18.19.2)(typescript@5.3.2)
       execa:
         specifier: ^8


### PR DESCRIPTION
## Changes

- also bump Astro to `^4.2.0` for Netlify
