### PR TITLE
fix(netlify): pre-rendered 404 pages aren't shown

### DIFF
--- a/.changeset/serious-kids-suffer.md
+++ b/.changeset/serious-kids-suffer.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+Fixes a bug in the Netlify Adapter where prerendered 404.astro pages weren't shown

--- a/.changeset/serious-kids-suffer.md
+++ b/.changeset/serious-kids-suffer.md
@@ -2,4 +2,4 @@
 '@astrojs/netlify': patch
 ---
 
-Fixes a bug in the Netlify Adapter where prerendered 404.astro pages weren't shown
+Fixes a bug in the Netlify Adapter where prerendered 404.astro pages weren't shown on hybrid/server deployments.

--- a/packages/netlify/src/ssr-function.ts
+++ b/packages/netlify/src/ssr-function.ts
@@ -13,11 +13,14 @@ const clientAddressSymbol = Symbol.for('astro.clientAddress');
 export const createExports = (manifest: SSRManifest, _args: Args) => {
 	const app = new App(manifest);
 
-	function createHandler(integrationConfig: { cacheOnDemandPages: boolean }) {
+	function createHandler(integrationConfig: { cacheOnDemandPages: boolean, notFoundContent?: string }) {
 		return async function handler(request: Request, context: Context) {
 			const routeData = app.match(request);
-			Reflect.set(request, clientAddressSymbol, context.ip);
+			if (!routeData && typeof integrationConfig.notFoundContent !== 'undefined') {
+				return new Response(integrationConfig.notFoundContent, { status: 404 });
+			}
 
+			Reflect.set(request, clientAddressSymbol, context.ip);
 			let locals: Record<string, unknown> = {};
 
 			const astroLocalsHeader = request.headers.get('x-astro-locals');

--- a/packages/netlify/test/functions/cookies.test.js
+++ b/packages/netlify/test/functions/cookies.test.js
@@ -23,4 +23,24 @@ describe('Cookies', () => {
 		expect(resp.headers.get('location')).to.equal('/');
 		expect(resp.headers.getSetCookie()).to.eql(['foo=foo; HttpOnly', 'bar=bar; HttpOnly']);
 	});
+
+	it("renders dynamic 404 page", async () => {
+		const entryURL = new URL(
+			'./fixtures/cookies/.netlify/functions-internal/ssr/ssr.mjs',
+			import.meta.url
+		);
+		const { default: handler } = await import(entryURL);
+		const resp = await handler(
+			new Request('http://example.com/nonexistant-page', {
+				headers: {
+					"x-test": "bar"
+				}
+			}),
+			{}
+		);
+		expect(resp.status).to.equal(404);
+		const text = await resp.text()
+		expect(text).to.contain("This is my custom 404 page");
+		expect(text).to.contain("x-test: bar");
+	})
 });

--- a/packages/netlify/test/functions/fixtures/cookies/src/pages/404.astro
+++ b/packages/netlify/test/functions/fixtures/cookies/src/pages/404.astro
@@ -1,0 +1,7 @@
+---
+export const prerender = false
+const header = Astro.request.headers.get("x-test")
+---
+
+<p>This is my custom 404 page</p>
+<p>x-test: {header}</p>

--- a/packages/netlify/test/functions/fixtures/redirects/src/pages/404.astro
+++ b/packages/netlify/test/functions/fixtures/redirects/src/pages/404.astro
@@ -1,0 +1,5 @@
+---
+export const prerender = true
+---
+
+<p>This is my static 404 page</p>

--- a/packages/netlify/test/functions/redirects.test.js
+++ b/packages/netlify/test/functions/redirects.test.js
@@ -1,5 +1,6 @@
 import { loadFixture } from '@astrojs/test-utils';
 import { expect } from 'chai';
+import { createServer } from 'http';
 
 describe('SSR - Redirects', () => {
 	let fixture;
@@ -40,4 +41,26 @@ describe('SSR - Redirects', () => {
 		const text = await resp.text()
 		expect(text).to.contain("This is my static 404 page");
 	})
+
+	it('does not pass through 404 request', async () => {
+		let testServerCalls = 0
+		const testServer = createServer((req, res) => {
+			testServerCalls++
+			res.writeHead(200)
+			res.end()
+		})
+		testServer.listen(5678)
+		const entryURL = new URL(
+			'./fixtures/redirects/.netlify/functions-internal/ssr/ssr.mjs',
+			import.meta.url
+		);
+		const { default: handler } = await import(entryURL);
+		const resp = await handler(
+			new Request('http://localhost:5678/nonexistant-page'),
+			{}
+		);
+		expect(resp.status).to.equal(404);
+		expect(testServerCalls).to.equal(0)
+		testServer.close()
+	});
 });

--- a/packages/netlify/test/functions/redirects.test.js
+++ b/packages/netlify/test/functions/redirects.test.js
@@ -25,4 +25,19 @@ describe('SSR - Redirects', () => {
 		}
 		expect(hasErrored).to.equal(true, 'this file should not exist');
 	});
+
+	it("renders static 404 page", async () => {
+		const entryURL = new URL(
+			'./fixtures/redirects/.netlify/functions-internal/ssr/ssr.mjs',
+			import.meta.url
+		);
+		const { default: handler } = await import(entryURL);
+		const resp = await handler(
+			new Request('http://example.com/nonexistant-page', ),
+			{}
+		);
+		expect(resp.status).to.equal(404);
+		const text = await resp.text()
+		expect(text).to.contain("This is my static 404 page");
+	})
 });


### PR DESCRIPTION
## Changes

Adds tests around 404 pages. Fixes prerendered 404 pages by embedding them into the SSR Handler and returning it when no route matches. There's other solutions to this, as we're discussing in https://github.com/withastro/adapters/issues/133, but this is a quick & easy fix to get 404 pages functioning.

## Testing

added two unit tests.

## Docs

It's a fix, so no docs needed. Related to https://github.com/withastro/adapters/issues/133.
