### PR TITLE
feat(netlify): verification for edge middleware

### DIFF
--- a/.changeset/odd-shoes-talk.md
+++ b/.changeset/odd-shoes-talk.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/netlify': minor
+---
+
+Implements verification for edge middleware. This is a security measure to ensure that your serverless functions are only ever called by your edge middleware and not by a third party.
+
+When `edgeMiddleware` is enabled, the serverless function will now respond with `403 Forbidden` for requests that are not verified to have come from the generated edge middleware. No user action is necessary.

--- a/packages/netlify/test/functions/fixtures/split-support/src/env.d.ts
+++ b/packages/netlify/test/functions/fixtures/split-support/src/env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="astro/client" />


### PR DESCRIPTION
## Changes
- Ensures that when `edgeMiddleware` is enabled, only the edge middleware can call the internal serverless function.


## Testing
Manual

## Docs
- https://github.com/withastro/docs/pull/6786