### PR TITLE
fix(netlify): serve prerendered 404 page with content-type: text/html

### DIFF
--- a/.changeset/large-fireants-wink.md
+++ b/.changeset/large-fireants-wink.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+Fixes bug where prerendered 404 pages were served as text/plain instead of text/html for hybrid/server apps, leading to browsers displaying source code instead of rendering it

--- a/.changeset/large-fireants-wink.md
+++ b/.changeset/large-fireants-wink.md
@@ -2,4 +2,4 @@
 '@astrojs/netlify': patch
 ---
 
-Fixes bug where prerendered 404 pages were served as text/plain instead of text/html for hybrid/server apps, leading to browsers displaying source code instead of rendering it
+Fixes bug where prerendered 404 pages were served as `text/plain` instead of `text/html` for hybrid/server apps, leading to browsers displaying source code instead of rendering it

--- a/packages/netlify/src/ssr-function.ts
+++ b/packages/netlify/src/ssr-function.ts
@@ -22,7 +22,10 @@ export const createExports = (manifest: SSRManifest, { middlewareSecret }: Args)
 		return async function handler(request: Request, context: Context) {
 			const routeData = app.match(request);
 			if (!routeData && typeof integrationConfig.notFoundContent !== 'undefined') {
-				return new Response(integrationConfig.notFoundContent, { status: 404 });
+				return new Response(integrationConfig.notFoundContent, {
+					status: 404,
+					headers: { 'Content-Type': 'text/html; charset=utf-8' },
+				});
 			}
 
 			Reflect.set(request, clientAddressSymbol, context.ip);

--- a/packages/netlify/test/functions/redirects.test.js
+++ b/packages/netlify/test/functions/redirects.test.js
@@ -35,6 +35,7 @@ describe('SSR - Redirects', () => {
 		const { default: handler } = await import(entryURL);
 		const resp = await handler(new Request('http://example.com/nonexistant-page'), {});
 		expect(resp.status).to.equal(404);
+		expect(resp.headers.get("content-type")).to.equal("text/html; charset=utf-8")
 		const text = await resp.text();
 		expect(text).to.contain('This is my static 404 page');
 	});


### PR DESCRIPTION
## Changes

Addresses https://github.com/withastro/adapters/pull/143#issuecomment-1934727870

We're serving the prerendered 404 page with the default content-type, which is `text/plain`. This leads browser to showing the contents of the page as source code, instead of rendering it!

The fix is to set the content-type to `text/html`. Doh!

## Testing

extended a test.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

it's a bugfix, no docs update needed.

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
