### PR TITLE
fix(netlify): replace `global.crypto` with `crypto`

### DIFF
--- a/.changeset/young-ravens-hammer.md
+++ b/.changeset/young-ravens-hammer.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/netlify": patch
+---
+
+Fixes an issue where using `global.crypto` failed for older Astro versions

--- a/.changeset/young-ravens-hammer.md
+++ b/.changeset/young-ravens-hammer.md
@@ -2,4 +2,4 @@
 "@astrojs/netlify": patch
 ---
 
-Fixes an issue where using `global.crypto` failed for older Astro versions
+Fixes an issue where some astro CLI commands failed with `crypto is not defined` on Astro 4.4.0 and earlier.

--- a/packages/netlify/src/index.ts
+++ b/packages/netlify/src/index.ts
@@ -6,6 +6,7 @@ import type { AstroConfig, AstroIntegration, RouteData } from 'astro';
 import { AstroError } from 'astro/errors';
 import { build } from 'esbuild';
 import { appendFile, mkdir, readFile, rm, writeFile } from 'fs/promises';
+import { randomUUID } from 'crypto'
 import type { Args } from './ssr-function.js';
 
 const { version: packageVersion } = JSON.parse(
@@ -77,7 +78,7 @@ export default function netlifyIntegration(
 	let rootDir: URL;
 	let astroMiddlewareEntryPoint: URL | undefined = undefined;
 	// Secret used to verify that the caller is the astro-generated edge middleware and not a third-party
-	const middlewareSecret = crypto.randomUUID();
+	const middlewareSecret = randomUUID();
 
 	const ssrOutputDir = () => new URL('./.netlify/functions-internal/ssr/', rootDir);
 	const middlewareOutputDir = () => new URL('.netlify/edge-functions/middleware/', rootDir);


### PR DESCRIPTION
## Changes

This is a drive by change because `randomUUID` is not on the global version of `crypto` on my node version (`v18.18.2`). I'm uncertain if this breaks any compatibility for others and do not have pnpm to run and commands.

## Testing

Not testing done because this is a trivial change and don't have pnpm

## Docs

Trivial change, probably should be noted in changelog
