### PR TITLE
fix(cloudflare): _routes.json deduplication

### DIFF
--- a/.changeset/sharp-cameras-rescue.md
+++ b/.changeset/sharp-cameras-rescue.md
@@ -2,4 +2,4 @@
 '@astrojs/cloudflare': patch
 ---
 
-Fixes automatic deduplication of `_routes.json`, which had more complex project structures
+Fixes an error with automatic deduplication of `_routes.json` for more complex project structures

--- a/.changeset/sharp-cameras-rescue.md
+++ b/.changeset/sharp-cameras-rescue.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes automatic deduplication of `_routes.json`, which had more complex project structures

--- a/packages/cloudflare/src/utils/deduplicatePatterns.ts
+++ b/packages/cloudflare/src/utils/deduplicatePatterns.ts
@@ -13,7 +13,7 @@ export function deduplicatePatterns(patterns: string[]) {
 	const uniquePatterns = [...new Set(patterns)];
 	for (const pattern of uniquePatterns) {
 		if (pattern.endsWith('*')) {
-			openPatterns.push(new RegExp(`^${pattern.replace(/(\*\/)*\*$/g, '[^*\n]*$')}`));
+			openPatterns.push(new RegExp(`^${pattern.replace(/(\*\/)*\*$/g, '(?=.{2,}).+[^*\n]$')}`));
 		}
 	}
 

--- a/packages/cloudflare/test/routes-json.test.js
+++ b/packages/cloudflare/test/routes-json.test.js
@@ -202,7 +202,7 @@ describe('_routes.json generation', () => {
 						assert.deepEqual(routes, {
 							version: 1,
 							include: ['/a/*', '/_image'],
-							exclude: ['/a/*', '/another'],
+							exclude: ['/a/', '/a/*', '/another'],
 						});
 					});
 				});


### PR DESCRIPTION
## Changes

- this should fix the deduplication error we had for more complex route definitions
- this is a fix for v9 of the adapter, in v10 we will refactor the complete route generation logic _(so this has a limited time to live)_
- also reverting change in test file https://github.com/withastro/adapters/pull/137/files#diff-d3130bfe10263d21a437f7e826fc4594ffc77e5cc37be1b09b10f5553b08c3ed
- closes https://github.com/withastro/adapters/issues/149

## Testing

- I personally don't think it is worth to add a complete fixture for such edge-case, however we can if anyone has strong opinions
- Let's investigate if we can add unit tests instead which test only util functions
