### PR TITLE
feat(cloudflare): add service bindings

### DIFF
--- a/.changeset/nervous-hotels-develop.md
+++ b/.changeset/nervous-hotels-develop.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': minor
+---
+
+Adds [Service bindings](https://developers.cloudflare.com/workers/configuration/bindings/about-service-bindings/) to the runtime bindings.

--- a/packages/cloudflare/src/tmp-types.d.ts
+++ b/packages/cloudflare/src/tmp-types.d.ts
@@ -108,6 +108,22 @@ interface CF_RawConfig {
 			environment?: string;
 		}[];
 	};
+	/**
+	 * A list of service bindings that your worker should be bound to.
+	 *
+	 * For more information about Service bindings, see the documentation at
+	 * https://developers.cloudflare.com/workers/configuration/bindings/about-service-bindings/
+	 *
+	 * NOTE: This field is not automatically inherited from the top level environment,
+	 * and so must be specified in every named environment.
+	 *
+	 * @default `[]`
+	 * @nonInheritable
+	 */
+	services: {
+		binding: string;
+		service: string;
+	}[];
 }
 
 interface CF_ServiceDesignator {

--- a/packages/cloudflare/src/utils/local-runtime.ts
+++ b/packages/cloudflare/src/utils/local-runtime.ts
@@ -42,7 +42,7 @@ type BASE_RUNTIME = {
 				};
 		  }
 		| ({
-				type: 'service-binding';
+				type: 'service';
 		  } & (
 				| {
 						address: string;
@@ -123,7 +123,7 @@ class LocalRuntime {
 						scriptName: bindingData.service?.name,
 					};
 					break;
-				case 'service-binding':
+				case 'service':
 					if ('address' in bindingData) {
 						// Pages mode
 						const isHttps = bindingData.protocol === 'https';
@@ -309,7 +309,7 @@ export class LocalWorkersRuntime extends LocalRuntime {
 		if (_wranglerConfig?.services) {
 			for (const service of _wranglerConfig.services) {
 				runtimeConfigWithWrangler.bindings[service.binding] = {
-					type: 'service-binding',
+					type: 'service',
 					service: service.service,
 				};
 			}

--- a/packages/cloudflare/src/utils/local-runtime.ts
+++ b/packages/cloudflare/src/utils/local-runtime.ts
@@ -6,7 +6,7 @@ import type {
 	R2Bucket,
 } from '@cloudflare/workers-types/experimental';
 import type { AstroConfig, AstroIntegrationLogger } from 'astro';
-import type { Json, ReplaceWorkersTypes, WorkerOptions } from 'miniflare';
+import type { ExternalServer, Json, ReplaceWorkersTypes, WorkerOptions } from 'miniflare';
 import type { Options } from '../index.js';
 
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'fs';
@@ -41,6 +41,17 @@ type BASE_RUNTIME = {
 					env?: string;
 				};
 		  }
+		| ({
+				type: 'service-binding';
+		  } & (
+				| {
+						address: string;
+						protocol?: 'http' | 'https';
+				  }
+				| {
+						service: string;
+				  }
+		  ))
 	>;
 };
 
@@ -89,6 +100,7 @@ class LocalRuntime {
 		const r2Bindings: Required<Pick<WorkerOptions, 'r2Buckets'>>['r2Buckets'] = [];
 		const durableObjectBindings: Required<Pick<WorkerOptions, 'durableObjects'>>['durableObjects'] =
 			{};
+		const serviceBindings: Required<Pick<WorkerOptions, 'serviceBindings'>>['serviceBindings'] = {};
 
 		for (const bindingName in runtimeConfig.bindings) {
 			const bindingData = runtimeConfig.bindings[bindingName];
@@ -111,6 +123,23 @@ class LocalRuntime {
 						scriptName: bindingData.service?.name,
 					};
 					break;
+				case 'service-binding':
+					if ('address' in bindingData) {
+						// Pages mode
+						const isHttps = bindingData.protocol === 'https';
+
+						const serviceBindingConfig: ExternalServer = isHttps
+							? { address: bindingData.address, https: {} }
+							: { address: bindingData.address, http: {} };
+
+						serviceBindings[bindingName] = {
+							external: serviceBindingConfig,
+						};
+					} else if ('service' in bindingData) {
+						// Worker mode
+						serviceBindings[bindingName] = bindingData.service;
+					}
+					break;
 			}
 		}
 
@@ -132,6 +161,7 @@ class LocalRuntime {
 					r2Buckets: r2Bindings,
 					kvNamespaces: kvBindings,
 					durableObjects: durableObjectBindings,
+					serviceBindings: serviceBindings,
 				},
 			],
 		});
@@ -273,6 +303,14 @@ export class LocalWorkersRuntime extends LocalRuntime {
 								name: durableObject.script_name,
 						  }
 						: undefined,
+				};
+			}
+		}
+		if (_wranglerConfig?.services) {
+			for (const service of _wranglerConfig.services) {
+				runtimeConfigWithWrangler.bindings[service.binding] = {
+					type: 'service-binding',
+					service: service.service,
 				};
 			}
 		}

--- a/packages/cloudflare/test/dev-runtime-workers.test.js
+++ b/packages/cloudflare/test/dev-runtime-workers.test.js
@@ -80,4 +80,12 @@ describe('DevRuntimeWorkers', () => {
 		const $ = cheerio.load(html);
 		assert.equal($('#hasDO').text(), 'true');
 	});
+
+	it('adds service bindings mocking', async () => {
+		const res = await fetch('http://127.0.0.1:4321/services');
+		const html = await res.text();
+		const $ = cheerio.load(html);
+		assert.equal($('#hasAUTH').text(), 'true');
+		assert.equal($('#hasLOGOUT').text(), 'true');
+	});
 });

--- a/packages/cloudflare/test/fixtures/dev-runtime-pages/astro.config.ts
+++ b/packages/cloudflare/test/fixtures/dev-runtime-pages/astro.config.ts
@@ -38,11 +38,11 @@ export default defineConfig({
 					className: 'DO_PROD',
 				},
 				AUTH: {
-					type: 'service-binding',
+					type: 'service',
 					address: '127.0.0.1:8787'
 				},
 				LOGOUT: {
-					type: 'service-binding',
+					type: 'service',
 					address: '127.0.0.1:8787'
 				}
 			},

--- a/packages/cloudflare/test/fixtures/dev-runtime-pages/astro.config.ts
+++ b/packages/cloudflare/test/fixtures/dev-runtime-pages/astro.config.ts
@@ -37,6 +37,14 @@ export default defineConfig({
 					type: 'durable-object',
 					className: 'DO_PROD',
 				},
+				AUTH: {
+					type: 'service-binding',
+					address: '127.0.0.1:8787'
+				},
+				LOGOUT: {
+					type: 'service-binding',
+					address: '127.0.0.1:8787'
+				}
 			},
 		},
 	}),

--- a/packages/cloudflare/test/fixtures/dev-runtime-pages/src/pages/services.astro
+++ b/packages/cloudflare/test/fixtures/dev-runtime-pages/src/pages/services.astro
@@ -1,0 +1,16 @@
+---
+const runtime = Astro.locals.runtime;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Service bindings</title>
+  </head>
+  <body>
+    <pre id="hasAUTH">{!!runtime.env.AUTH && typeof runtime.env.AUTH.fetch === 'function'}</pre>
+    <pre id="hasLOGOUT">{!!runtime.env.LOGOUT && typeof runtime.env.AUTH.fetch === 'function'}</pre>
+  </body>
+</html>

--- a/packages/cloudflare/test/fixtures/dev-runtime-workers/src/pages/services.astro
+++ b/packages/cloudflare/test/fixtures/dev-runtime-workers/src/pages/services.astro
@@ -1,0 +1,16 @@
+---
+const runtime = Astro.locals.runtime;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Service bindings</title>
+  </head>
+  <body>
+    <pre id="hasAUTH">{!!runtime.env.AUTH && typeof runtime.env.AUTH.fetch === 'function'}</pre>
+    <pre id="hasLOGOUT">{!!runtime.env.LOGOUT && typeof runtime.env.AUTH.fetch === 'function'}</pre>
+  </body>
+</html>

--- a/packages/cloudflare/test/fixtures/dev-runtime-workers/wrangler.toml
+++ b/packages/cloudflare/test/fixtures/dev-runtime-workers/wrangler.toml
@@ -35,3 +35,11 @@ class_name = "DurableObjectExample"
 [[durable_objects.bindings]]
 name = "DO_PROD"
 class_name = "DurableObjectProductionExample"
+
+[[services]]
+binding = "AUTH"
+service = "worker" # local-runtime.ts:154
+
+[[services]]
+binding = "LOGOUT"
+service = "worker" # local-runtime.ts:154

--- a/packages/cloudflare/test/z-dev-runtime-pages.test.js
+++ b/packages/cloudflare/test/z-dev-runtime-pages.test.js
@@ -80,4 +80,12 @@ describe('DevRuntimePages', () => {
 		const $ = cheerio.load(html);
 		assert.equal($('#hasDO').text(), 'true');
 	});
+
+	it('adds service bindings mocking', async () => {
+		const res = await fetch('http://127.0.0.1:4321/services');
+		const html = await res.text();
+		const $ = cheerio.load(html);
+		assert.equal($('#hasAUTH').text(), 'true');
+		assert.equal($('#hasLOGOUT').text(), 'true');
+	});
 });


### PR DESCRIPTION
## Changes

- This change introduces [Service bindings](https://developers.cloudflare.com/workers/configuration/bindings/about-service-bindings/) to the `@astrojs/cloudflare` adapter.
- Both setting the service bindings via `astro.config.ts` (`pages` type) and reading them from `wrangler.toml` (`workers` type) have been implemented.

## Testing

Changes have been tested by updating the `dev-runtime-pages` and `dev-runtime-workers` fixtures and adding an integration test to `z-dev-runtime-pages.test.js` and `dev-runtime-workers.test.js` respectively.

## Docs

Since this is a feature, it does not affect current users, but the [documentation](https://docs.astro.build/en/guides/integrations-guide/cloudflare/) will need to be updated.

closes #175 
