### PR TITLE
feat(netlify): add support for image.remotePatterns and images.domains with Netlify Image CDN

### DIFF
--- a/.changeset/nine-lamps-cry.md
+++ b/.changeset/nine-lamps-cry.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': minor
+---
+
+Adds support for image.remotePatterns and images.domains with Netlify Image CDN

--- a/.changeset/nine-lamps-cry.md
+++ b/.changeset/nine-lamps-cry.md
@@ -2,4 +2,4 @@
 '@astrojs/netlify': minor
 ---
 
-Adds support for image.remotePatterns and images.domains with Netlify Image CDN
+Adds support for `image.remotePatterns` and `images.domains` with Netlify Image CDN

--- a/packages/netlify/src/index.ts
+++ b/packages/netlify/src/index.ts
@@ -41,14 +41,14 @@ export function remotePatternToRegex({
 		regexStr += `${protocol}://`;
 	} else {
 		// Default to matching any protocol
-		regexStr += '[a-z]+://'; 
+		regexStr += '[a-z]+://';
 	}
 
 	if (hostname) {
 		if (hostname.startsWith('**.')) {
 			// match any number of subdomains
 			regexStr += '([a-z0-9]+\\.)*';
-			hostname = hostname.substring(3); 
+			hostname = hostname.substring(3);
 		} else if (hostname.startsWith('*.')) {
 			// match one subdomain
 			regexStr += '([a-z0-9]+\\.)?';
@@ -64,20 +64,20 @@ export function remotePatternToRegex({
 		regexStr += `:${port}`;
 	} else {
 		// Default to matching any port
-		regexStr += '(:[0-9]+)?'; 
+		regexStr += '(:[0-9]+)?';
 	}
 
 	if (pathname) {
 		if (pathname.endsWith('/**')) {
 			// Match any path. Return early because there's no need to add more to the regex
-			return  `${regexStr}(\\${pathname.replace('/**', '')}.*)`;
+			return `${regexStr}(\\${pathname.replace('/**', '')}.*)`;
 		}
 		if (pathname.endsWith('/*')) {
 			// Match one level of path
 			regexStr += `(\\${pathname.replace('/*', '')}\/[^/?#]+)\/?`;
 		} else {
 			// Exact match
-			regexStr += `(\\${pathname})`; 
+			regexStr += `(\\${pathname})`;
 		}
 	} else {
 		// Default to matching any path

--- a/packages/netlify/src/index.ts
+++ b/packages/netlify/src/index.ts
@@ -62,7 +62,7 @@ export function remotePatternToRegex({
 	if (pathname) {
 		if (pathname.endsWith('/**')) {
 			// Match any path. Return early because there's no need to add more to the regex
-			return regexStr + `(\\${pathname.replace('/**', '')}.*)`;
+			return  `${regexStr}(\\${pathname.replace('/**', '')}.*)`;
 		}
 		if (pathname.endsWith('/*')) {
 			// Match one level of path

--- a/packages/netlify/src/index.ts
+++ b/packages/netlify/src/index.ts
@@ -91,7 +91,9 @@ export function remotePatternToRegex({
 async function writeNetlifyDeployConfig(config: AstroConfig) {
 	const remoteImages: Array<string> = [];
 	// Domains get a simple regex match
-	remoteImages.push(...config.image.domains.map((domain) => `https?:/\/${domain}\/.*`));
+	remoteImages.push(
+		...config.image.domains.map((domain) => `https?:/\/${domain.replaceAll('.', '\\.')}\/.*`)
+	);
 	// Remote patterns need to be converted to regex
 	remoteImages.push(...config.image.remotePatterns.map(remotePatternToRegex));
 

--- a/packages/netlify/test/functions/fixtures/middleware/astro.config.mjs
+++ b/packages/netlify/test/functions/fixtures/middleware/astro.config.mjs
@@ -13,7 +13,7 @@ export default defineConfig({
       hostname: '*.example.org',
       pathname: '/images/*',
     }],
-    domains: ['example.net'],
+    domains: ['example.net', 'secret.example.edu'],
   },
   site: `http://example.com`,
 });

--- a/packages/netlify/test/functions/fixtures/middleware/astro.config.mjs
+++ b/packages/netlify/test/functions/fixtures/middleware/astro.config.mjs
@@ -7,5 +7,13 @@ export default defineConfig({
     edgeMiddleware: process.env.EDGE_MIDDLEWARE === 'true',
     imageCDN: process.env.DISABLE_IMAGE_CDN ? false : undefined,
   }),
+  image: {
+    remotePatterns: [{
+      protocol: 'https',
+      hostname: '*.example.org',
+      pathname: '/images/*',
+    }],
+    domains: ['example.net'],
+  },
   site: `http://example.com`,
 });

--- a/packages/netlify/test/functions/image-cdn.test.js
+++ b/packages/netlify/test/functions/image-cdn.test.js
@@ -55,7 +55,7 @@ describe('Image CDN', () => {
 		});
 
 		it('generates remote image config patterns', async () => {
-			assert.equal(regexes?.length, 2);
+			assert.equal(regexes?.length, 3);
 		});
 
 		it('generates correct config for domains', async () => {
@@ -72,11 +72,22 @@ describe('Image CDN', () => {
 				true,
 				'subpath should match'
 			);
+			const subdomain = regexes[1];
+			assert.equal(
+				subdomain.test('https://secret.example.edu/image.jpg'),
+				true,
+				'should match subdomains'
+			);
+			assert.equal(
+				subdomain.test('https://secretxexample.edu/image.jpg'),
+				false,
+				'should not use dots in domains as wildcards'
+			);
 		});
 
 		it('generates correct config for remotePatterns', async () => {
-			const patterns = regexes[1];
-			assert.equal(patterns.test('https://example.org/images/1.jpg'), true);
+			const patterns = regexes[2];
+			assert.equal(patterns.test('https://example.org/images/1.jpg'), true, 'should match domain');
 			assert.equal(
 				patterns.test('https://www.example.org/images/2.jpg'),
 				true,

--- a/packages/netlify/test/functions/image-cdn.test.js
+++ b/packages/netlify/test/functions/image-cdn.test.js
@@ -1,5 +1,6 @@
 import * as assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
+import { remotePatternToRegex } from '@astrojs/netlify';
 import { loadFixture } from '@astrojs/test-utils';
 
 describe('Image CDN', () => {
@@ -102,6 +103,26 @@ describe('Image CDN', () => {
 				patterns.test('https://example.org/not-images/2.jpg'),
 				false,
 				'wrong path should not match'
+			);
+		});
+
+		it('warns when remotepatterns generates an invalid regex', async (t) => {
+			const logger = {
+				warn: t.mock.fn(),
+			};
+			const regex = remotePatternToRegex(
+				{
+					hostname: '*.examp[le.org',
+					pathname: '/images/*',
+				},
+				logger
+			);
+			assert.strictEqual(regex, undefined);
+			const calls = logger.warn.mock.calls;
+			assert.strictEqual(calls.length, 1);
+			assert.equal(
+				calls[0].arguments[0],
+				'Could not generate a valid regex from the remotePattern "{"hostname":"*.examp[le.org","pathname":"/images/*"}". Please check the syntax.'
 			);
 		});
 	});

--- a/packages/netlify/test/hosted/hosted-astro-project/astro.config.mjs
+++ b/packages/netlify/test/hosted/hosted-astro-project/astro.config.mjs
@@ -11,7 +11,7 @@ export default defineConfig({
 				protocol: 'https',
 				hostname: 'images.unsplash.com',
 				pathname: '/photo-1567674867291-b2595ac53ab4',
-			}
-		]
-	}
+			},
+		],
+	},
 });

--- a/packages/netlify/test/hosted/hosted-astro-project/astro.config.mjs
+++ b/packages/netlify/test/hosted/hosted-astro-project/astro.config.mjs
@@ -5,4 +5,13 @@ import { defineConfig } from 'astro/config';
 export default defineConfig({
 	output: 'server',
 	adapter: netlify(),
+	image: {
+		remotePatterns: [
+			{
+				protocol: 'https',
+				hostname: 'images.unsplash.com',
+				pathname: '/photo-1567674867291-b2595ac53ab4',
+			}
+		]
+	}
 });

--- a/packages/netlify/test/hosted/hosted-astro-project/netlify.toml
+++ b/packages/netlify/test/hosted/hosted-astro-project/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+command = "pnpm run --filter @test/netlify-hosted-astro-project... build"
+publish = "/packages/netlify/test/hosted/hosted-astro-project/dist"

--- a/packages/netlify/test/hosted/hosted-astro-project/src/pages/index.astro
+++ b/packages/netlify/test/hosted/hosted-astro-project/src/pages/index.astro
@@ -4,3 +4,10 @@ import penguin from '../assets/penguin.png';
 ---
 
 <Image src={penguin} width={300} alt="" />
+
+<Image
+	src="https://images.unsplash.com/photo-1567674867291-b2595ac53ab4"
+	width={300}
+	height={400}
+	alt="Astro"
+/>


### PR DESCRIPTION
## Changes

Previously the Netlify adapter was not able to enable support for remote images. This PR adds support for `image.remotePatterns` and `images.domains` config options. If a user sets these then the adapter converts them into regexes and writes them to Netlify's `images.remote_images` config option.

## Testing

Added a test image to the fixture site. Added tests for generating the patterns and the config file.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Docs PR: https://github.com/withastro/docs/pull/7375

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
