### PR TITLE
fix(cloudflare): fix typo in .dev.vars log message

### DIFF
--- a/.changeset/strange-eels-smell.md
+++ b/.changeset/strange-eels-smell.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/cloudflare": patch
+---
+
+Fixes a typo for a Cloudflare runtime .dev.vars warning

--- a/packages/cloudflare/src/utils/local-runtime.ts
+++ b/packages/cloudflare/src/utils/local-runtime.ts
@@ -186,7 +186,7 @@ class LocalRuntime {
 				const e = error as NodeJSError;
 				if (e.code === 'ENOENT') {
 					this._logger.info(
-						'There is no `.dev.vars` file in the root directory, if you have encrypted secrets or environmental variables you Cloudflare recommends to put them in this file'
+						'There is no `.dev.vars` file in the root directory, if you have encrypted secrets or environmental variables Cloudflare recommends you to put them in this file'
 					);
 					this.secrets = {};
 				} else {


### PR DESCRIPTION
Very minor, just a typo fix as I noticed it locally 🙂 
