### PR TITLE
fix(cloudflare): align runtime api

### DIFF
--- a/.changeset/selfish-spoons-mix.md
+++ b/.changeset/selfish-spoons-mix.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes `locals.runtime` API to match between `astro dev` and `astro build`

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -16,8 +16,7 @@
   "homepage": "https://docs.astro.build/en/guides/integrations-guide/cloudflare/",
   "exports": {
     ".": "./dist/index.js",
-    "./entrypoints/server.advanced.js": "./dist/entrypoints/server.advanced.js",
-    "./entrypoints/server.directory.js": "./dist/entrypoints/server.directory.js",
+    "./entrypoints/server.js": "./dist/entrypoints/server.js",
     "./image-service": "./dist/entrypoints/image-service.js",
     "./image-endpoint": "./dist/entrypoints/image-endpoint.js",
     "./package.json": "./package.json"

--- a/packages/cloudflare/src/entrypoints/server.ts
+++ b/packages/cloudflare/src/entrypoints/server.ts
@@ -13,10 +13,10 @@ type Env = {
 
 export interface Runtime<T extends object = object> {
 	runtime: {
-		waitUntil: (promise: Promise<any>) => void;
 		env: Env & T;
 		cf: CLOUDFLARE_REQUEST['cf'];
 		caches: CLOUDFLARE_CACHESTORAGE;
+		ctx: ExecutionContext;
 	};
 }
 
@@ -60,12 +60,13 @@ export function createExports(manifest: SSRManifest) {
 
 		const locals: Runtime = {
 			runtime: {
-				waitUntil: (promise: Promise<any>) => {
-					context.waitUntil(promise);
-				},
 				env: env,
 				cf: request.cf,
 				caches: caches as unknown as CLOUDFLARE_CACHESTORAGE,
+				ctx: {
+					waitUntil: (promise: Promise<any>) => context.waitUntil(promise),
+					passThroughOnException: () => context.passThroughOnException(),
+				},
 			},
 		};
 

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -15,7 +15,7 @@ import { createRoutesFile, getParts } from './utils/generate-routes-json.js';
 import { setImageConfig } from './utils/image-config.js';
 import { wasmModuleLoader } from './utils/wasm-module-loader.js';
 
-export type { Runtime } from './entrypoints/server.advanced.js';
+export type { Runtime } from './entrypoints/server.js';
 
 export type Options = {
 	/** Options for handling images. */
@@ -100,7 +100,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 
 				setAdapter({
 					name: '@astrojs/cloudflare',
-					serverEntrypoint: '@astrojs/cloudflare/entrypoints/server.advanced.js',
+					serverEntrypoint: '@astrojs/cloudflare/entrypoints/server.js',
 					exports: ['default'],
 					adapterFeatures: {
 						functionPerRoute: false,
@@ -135,7 +135,10 @@ export default function createIntegration(args?: Options): AstroIntegration {
 								env: platformProxy.env,
 								cf: platformProxy.cf,
 								caches: platformProxy.caches,
-								ctx: platformProxy.ctx,
+								ctx: {
+									waitUntil: (promise: Promise<any>) => platformProxy.ctx.waitUntil(promise),
+									passThroughOnException: () => platformProxy.ctx.passThroughOnException(),
+								},
 							},
 						});
 						next();


### PR DESCRIPTION
## Changes

- renames server entry
- deletes old exports definition
- updates `locals.runtime` API in production to match development

## Testing

- existing tests

## Docs

- bug fix of already documented behavior, no new docs needed
