### PR TITLE
workaround prerender in pageMap

### DIFF
--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -97,7 +97,13 @@ export default function createIntegration(args?: Options): AstroIntegration {
 									// Loop through all chunks and find out which pages are prerendered
 									for (const chunk of Object.values(bundle)) {
 										if (chunk.type !== 'chunk') continue;
-										if (chunk.dynamicImports.some((entry) => entry.includes('prerender'))) {
+										if (
+											chunk.dynamicImports.some(
+												(entry) =>
+													entry.includes('prerender') &&
+													chunk.name !== '_@astrojs-ssr-virtual-entry'
+											)
+										) {
 											prerenderImports.push([chunk.facadeModuleId ?? '', chunk.fileName]);
 										}
 									}

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -126,7 +126,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 												}
 												chunk.code = chunk.code.replace(importRegex, '');
 												if (pageId) {
-													const arrayRegex = new RegExp(`^^ +\\[".+", ${pageId}\\]$\\n`, 'gm');
+													const arrayRegex = new RegExp(`^ +\\[".+", ${pageId}\\]$\\n`, 'gm');
 													chunk.code = chunk.code.replace(arrayRegex, '');
 												}
 											}

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -227,7 +227,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 
 					vite.ssr ||= {};
 					vite.ssr.target = 'webworker';
-					vite.ssr.noExternal ||= true;
+					vite.ssr.noExternal = true;
 
 					if (typeof _config.vite.ssr?.external === 'undefined') vite.ssr.external = [];
 					if (typeof _config.vite.ssr?.external === 'boolean')

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -127,7 +127,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 											const pageSource = page[0].split(':')[1].replace('@_@', '.');
 											entryChunk.code = entryChunk.code.replace(importRegex, '');
 											if (pageId) {
-												const arrayRegex = new RegExp(`\\["${pageSource}", ${pageId}\\]`, 'gm');
+												const arrayRegex = new RegExp(`\\["${pageSource}", ?${pageId}\\],?`, 'gm');
 												entryChunk.code = entryChunk.code.replace(arrayRegex, '');
 											}
 										}


### PR DESCRIPTION
we need to plugins so we can use `generateBundle` twice. Any other hook doesn't have file names with hashes already, and using `writeBundle` would need `fs` operation, which I think is worse.

`regex` is scary, but I'm not sure if it is worth to create an ast and convert back to string again