### PR TITLE
fix(cloudflare): don't cleanup client bundle

### DIFF
--- a/.changeset/silent-kings-matter.md
+++ b/.changeset/silent-kings-matter.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes an issue where the bundle was not cleaned up correctly

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -367,8 +367,17 @@ export default function createIntegration(args?: Options): AstroIntegration {
 				// Those modules are build only for prerendering routes.
 				const chunksToDelete = chunkAnalyzer.getNonServerChunks();
 				for (const chunk of chunksToDelete) {
-					// Chunks are located on `./_worker.js` directory inside of the output directory
-					await unlink(new URL(`./_worker.js/${chunk}`, _config.outDir));
+					try {
+						// Chunks are located on `./_worker.js` directory inside of the output directory
+						await unlink(new URL(`./_worker.js/${chunk}`, _config.outDir));
+					} catch (error) {
+						logger.warn(
+							`Issue while trying to delete unused file from server bundle: ${new URL(
+								`./_worker.js/${chunk}`,
+								_config.outDir
+							).toString()}`
+						);
+					}
 				}
 			},
 		},

--- a/packages/cloudflare/src/utils/index.ts
+++ b/packages/cloudflare/src/utils/index.ts
@@ -23,7 +23,7 @@ export function mutatePageMapInPlace(
 				// @ts-expect-error - @types/estree seem to be wrong
 				s.remove(arrayExpression.start, arrayExpression.end);
 
-				// We need to check if there are any lefover commas, which are not part of the `ArrayExpression` node
+				// We need to check if there are any leftover commas, which are not part of the `ArrayExpression` node
 				// @ts-expect-error - @types/estree seem to be wrong
 				const endChar = s.slice(arrayExpression.end, arrayExpression.end + 1);
 				if (endChar.includes(',')) {

--- a/packages/cloudflare/src/utils/index.ts
+++ b/packages/cloudflare/src/utils/index.ts
@@ -22,6 +22,14 @@ export function mutatePageMapInPlace(
 			if (arrayExpression.start && arrayExpression.end) {
 				// @ts-expect-error - @types/estree seem to be wrong
 				s.remove(arrayExpression.start, arrayExpression.end);
+
+				// We need to check if there are any lefover commas, which are not part of the `ArrayExpression` node
+				// @ts-expect-error - @types/estree seem to be wrong
+				const endChar = s.slice(arrayExpression.end, arrayExpression.end + 1);
+				if (endChar.includes(',')) {
+					// @ts-expect-error - @types/estree seem to be wrong
+					s.remove(arrayExpression.end, arrayExpression.end + 1);
+				}
 			}
 		}
 	}

--- a/packages/cloudflare/src/utils/non-server-chunk-detector.ts
+++ b/packages/cloudflare/src/utils/non-server-chunk-detector.ts
@@ -15,6 +15,8 @@ export class NonServerChunkDetector {
 		return {
 			name: 'non-server-chunk-detector',
 			generateBundle: (_, bundle) => {
+				// Skip if we bundle for client
+				if (!bundle['index.js']) return;
 				this.processBundle(bundle);
 			},
 		};


### PR DESCRIPTION
## Changes

- if the plugin runs for `client` it overrides, `nonServerChunks` with an empty array, leading to not removing the unused chunks
- closes https://github.com/withastro/adapters/issues/245
- closes https://github.com/withastro/adapters/issues/244

## Testing

- I was not able to figure out why the existing tests didn't catch this, might be a super edge case 🤔 


## Docs

- internal
- bug-fix
- no docs needed
