### PR TITLE
fix(netlify): shim process.env in edge middleware

### DIFF
--- a/.changeset/wet-dragons-count.md
+++ b/.changeset/wet-dragons-count.md
@@ -2,4 +2,4 @@
 '@astrojs/netlify': patch
 ---
 
-Define `process.env` in edge middleware
+Fixes an issue with edge middleware where `process.env` was not defined, by using a polyfill to shim it

--- a/.changeset/wet-dragons-count.md
+++ b/.changeset/wet-dragons-count.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+Define `process.env` in edge middleware

--- a/packages/netlify/src/index.ts
+++ b/packages/netlify/src/index.ts
@@ -266,6 +266,10 @@ export default function netlifyIntegration(
 			format: 'esm',
 			bundle: true,
 			minify: false,
+			banner: {
+				// Import Deno polyfill for `process.env` at the top of the file
+                js: 'import process from "node:process";',
+            },
 		});
 	}
 

--- a/packages/netlify/src/index.ts
+++ b/packages/netlify/src/index.ts
@@ -268,8 +268,8 @@ export default function netlifyIntegration(
 			minify: false,
 			banner: {
 				// Import Deno polyfill for `process.env` at the top of the file
-                js: 'import process from "node:process";',
-            },
+				js: 'import process from "node:process";',
+			},
 		});
 	}
 


### PR DESCRIPTION
## Changes

Netlify Edge Functions don't define `process.env`, but Vite uses it for any code that accesses `import.meta.env`. This PR imports the Deno `node:process` polyfill at the top of the bundled  middleware edge function

Fixes https://github.com/withastro/adapters/issues/254

## Testing

Tested with repro site https://github.com/jamesarosen/astro-broken-middleware-demo

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
