### PR TITLE
fix: use absolute path for included files

### DIFF
--- a/.changeset/yellow-cooks-hunt.md
+++ b/.changeset/yellow-cooks-hunt.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+Fixes an issue where files were not included in the SSR function when built in a monorepo

--- a/packages/netlify/src/index.ts
+++ b/packages/netlify/src/index.ts
@@ -259,7 +259,7 @@ export default function netlifyIntegration(
 			JSON.stringify({
 				config: {
 					nodeBundler: 'none',
-					includedFiles: ['.netlify/functions-internal/ssr/**/*'],
+					includedFiles: [fileURLToPath(new URL('.netlify/functions-internal/ssr/**/*', rootDir))],
 				},
 				version: 1,
 			})


### PR DESCRIPTION
## Changes

The adapter adds an `included_files` option to the SSR function manifest to ensure that all traced files are included in the bundle. The path is currently relative to the root of the site, which breaks when in a monorepo. This PR changes the path to be absolute, which works everywhere. Using an absolute path is fine because bundling always happens on the same machine as the build.

Fixes #309 

## Testing

Test deploy: https://66826aaccd6edbca0c286764--fascinating-belekoy-dfd085.netlify.app/

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
