### PR TITLE
feat(netlify): set cache headers for assets

### DIFF
--- a/.changeset/ten-chicken-provide.md
+++ b/.changeset/ten-chicken-provide.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': minor
+---
+
+Sets immutable cache headers for static assets

--- a/packages/netlify/test/static/fixtures/redirects/astro.config.mjs
+++ b/packages/netlify/test/static/fixtures/redirects/astro.config.mjs
@@ -2,10 +2,9 @@ import netlify from '@astrojs/netlify';
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
-  output: 'static',
-  adapter: netlify(),
-  site: `http://example.com`,
-  site: `http://example.com`,
+	output: 'static',
+	adapter: netlify(),
+	site: "http://example.com",
 	redirects: {
 		'/other': '/',
 		'/two': {

--- a/packages/netlify/test/static/headers.test.js
+++ b/packages/netlify/test/static/headers.test.js
@@ -1,0 +1,25 @@
+import * as assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import { loadFixture } from '@astrojs/test-utils';
+
+describe('SSG - headers', () => {
+	let fixture;
+
+	before(async () => {
+		fixture = await loadFixture({ root: new URL('./fixtures/redirects/', import.meta.url) });
+		await fixture.build();
+	});
+
+	it('Generates headers for static assets', async () => {
+		const config = await fixture.readFile('../.netlify/v1/config.json');
+		const headers = JSON.parse(config).headers;
+		assert.deepEqual(headers, [
+			{
+				for: '/_astro/*',
+				values: {
+					'Cache-Control': 'public, max-age=31536000, immutable',
+				},
+			},
+		]);
+	});
+});


### PR DESCRIPTION
## Changes

Adds immutable cache headers for everything in the assets directory. This is safe because they all have hashed filenames

## Testing

Added a test, and manually checked a deployed site

## Docs

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
