### PR TITLE
chore(actions): allow users with write access to publish preview releases

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -25,10 +25,10 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: "Check if user has admin access (only admins can publish snapshot releases)."
+      - name: "Check if user has write access"
         uses: "lannonbr/repo-permission-check-action@2.0.2"
         with:
-          permission: "admin"
+          permission: "write"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Changes

Updates the snapshot action to allow all users with write access to publish snapshots, rather than just admins. This matches the behaviour in the main monorepo.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
