### PR TITLE
Apply polyfills right away

### DIFF
--- a/.changeset/thirty-panthers-wave.md
+++ b/.changeset/thirty-panthers-wave.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/netlify': patch
+---
+
+Apply polyfills immediately on function execution
+
+This moves up when the polyfills are applied so that they are present before Astro runs, preventing a race condition that can cause `crypto` to not be defined early enough in Node 18.

--- a/packages/netlify/src/index.ts
+++ b/packages/netlify/src/index.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { appendFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import type { IncomingMessage } from 'node:http';
 import { fileURLToPath } from 'node:url';
 import { emptyDir } from '@astrojs/internal-helpers/fs';
@@ -495,7 +495,7 @@ export default function netlifyIntegration(
 
 			// local dev
 			'astro:server:setup': async ({ server }) => {
-				server.middlewares.use((req, res, next) => {
+				server.middlewares.use((req, _res, next) => {
 					const locals = Symbol.for('astro.locals');
 					Reflect.set(req, locals, {
 						...Reflect.get(req, locals),

--- a/packages/netlify/src/ssr-function.ts
+++ b/packages/netlify/src/ssr-function.ts
@@ -3,13 +3,13 @@ import type { SSRManifest } from 'astro';
 import { App } from 'astro/app';
 import { applyPolyfills } from 'astro/app/node';
 
+applyPolyfills();
+
 // Won't throw if the virtual module is not available because it's not supported in
 // the users's astro version or if astro:env is not enabled in the project
 await import('astro/env/setup')
 	.then((mod) => mod.setGetEnv((key) => process.env[key]))
 	.catch(() => {});
-
-applyPolyfills();
 
 export interface Args {
 	middlewareSecret: string;


### PR DESCRIPTION
## Changes

- Same change we made to the Node adapter earlier.
- Prevents race condition where `crypto` could be used before the polyfill is applied.

## Testing

- Tested via the server-islands project.

## Docs

N/A, bug fix