### PR TITLE
ci: adds a workflow to listen to event dispatch

### DIFF
--- a/.github/workflows/event-dispatch.yml
+++ b/.github/workflows/event-dispatch.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4
 
       - name: Get commit ID (workflow dispatch, empty)
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit-id == '' }}
@@ -63,7 +63,7 @@ jobs:
           path: astro
 
       - name: Compile and link Astro
-        working-directory: astro
+        working-directory: astro/packages/astro
         run: |
           pnpm install
           pnpm run build
@@ -71,7 +71,7 @@ jobs:
       - name: Install dependencies, link Astro and build
         run: |
           pnpm install
-          pnpm link astro/withastro/astro
+          pnpm link astro/packages/astro
           pnpm run build
 
       - name: Run tests

--- a/.github/workflows/event-dispatch.yml
+++ b/.github/workflows/event-dispatch.yml
@@ -22,9 +22,6 @@ jobs:
   synchronize:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
       - name: Get commit ID (workflow dispatch, empty)
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit-id == '' }}
         run: echo "You must provide a full commit ID." && exit 1

--- a/.github/workflows/event-dispatch.yml
+++ b/.github/workflows/event-dispatch.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
   repository_dispatch:
-    types: [biome-push-main-event]
+    types: [astro-push-main-event]
 
 permissions:
   actions: write

--- a/.github/workflows/event-dispatch.yml
+++ b/.github/workflows/event-dispatch.yml
@@ -1,0 +1,78 @@
+name: Event dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      commit-id:
+        description: Commit ID of withastro/astro
+        required: true
+        type: string
+  repository_dispatch:
+    types: [biome-push-main-event]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  synchronize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Get commit ID (workflow dispatch, empty)
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit-id == '' }}
+        run: echo "You must provide a full commit ID." && exit 1
+
+      - name: Get commit ID (workflow dispatch, non-empty)
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit-id != '' }}
+        run: echo "COMMIT_ID=${{ github.event.inputs.commit-id }}" >> $GITHUB_ENV
+
+      - name: Get commit ID (repository dispatch)
+        if: ${{ github.event_name == 'repository_dispatch'}}
+        run: echo "COMMIT_ID=${{ github.event.client_payload.event.head_commit.id }}" >> "$GITHUB_ENV"
+
+      - name: Get short commit ID
+        run: echo "SHORT_COMMIT_ID=$(echo ${{ env.COMMIT_ID }} | cut -c 1-7)" >> "$GITHUB_ENV"
+
+      - name: Disable git crlf
+        run: git config --global core.autocrlf false
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Checkout Astro repository
+        uses: actions/checkout@v4
+        with:
+          repository: withastro/astro
+          ref: ${{ env.COMMIT_ID }}
+          path: astro
+
+      - name: Compile and link Astro
+        working-directory: astro
+        run: |
+          pnpm install
+          pnpm run build
+
+      - name: Install dependencies, link Astro and build
+        run: |
+          pnpm install
+          pnpm link astro/withastro/astro
+          pnpm run build
+
+      - name: Run tests
+        run: pnpm test


### PR DESCRIPTION
## Changes

Adds a workflow that listens to the event dispatch added in `withastro/astro`.

The workflow does the following:
- it extracts the commit ID sent by the event
- it checks out `withastro/astro` using the commit ID as `ref`
- it builds the whole repository
- it links the astro package
- it runs the tests for all the adapters

## Testing

We should merge this PR. However I still need to fix a small bug in `withastro/astro`

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
