### PR TITLE
chore: build whole repo due to interconnected deps

### DIFF
--- a/.github/workflows/event-dispatch.yml
+++ b/.github/workflows/event-dispatch.yml
@@ -65,11 +65,20 @@ jobs:
           pnpm install
           pnpm run build
 
-      - name: Install dependencies, link Astro and build
+      - name: Install dependencies
         run: |
           pnpm install
-          pnpm link astro/packages/astro
-          pnpm run build
 
-      - name: Run tests
-        run: pnpm test
+      - name: Test Cloudflare
+        working-directory: packages/cloudflare
+        run: |
+          pnpm link ../../astro/packages/astro
+          pnpm run build
+          pnpm run test
+
+      - name: Test Netlify
+        working-directory: packages/netlify
+        run: |
+          pnpm link ../../astro/packages/astro
+          pnpm run build
+          pnpm run test

--- a/.github/workflows/event-dispatch.yml
+++ b/.github/workflows/event-dispatch.yml
@@ -60,7 +60,7 @@ jobs:
           path: astro
 
       - name: Compile and link Astro
-        working-directory: astro/packages/astro
+        working-directory: astro
         run: |
           pnpm install
           pnpm run build


### PR DESCRIPTION
## Changes

https://github.com/withastro/adapters/actions/runs/10493012888/job/29065900246#step:12:39

This changes the workflow to run singularly the link to the astro package directly in the adapters. Doing it in at the top-level of the monorepo might not work.


## Testing

I tested it locally

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
