### PR TITLE
fix: ISR opt out for routes with rest parameters

### DIFF
--- a/.changeset/early-scissors-wait.md
+++ b/.changeset/early-scissors-wait.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Fix excluding routes with rest parameters from ISR

--- a/packages/vercel/src/lib/redirects.ts
+++ b/packages/vercel/src/lib/redirects.ts
@@ -45,25 +45,28 @@ function getParts(part: string, file: string) {
 // 2022-04-26
 function getMatchPattern(segments: RoutePart[][]) {
 	return segments
-		.map((segment) => {
-			return segment[0].spread
+		.map((segment, segmentIndex) => {
+			return segment.length === 1 && segment[0].spread
 				? '(?:\\/(.*?))?'
-				: segment
+				: (segmentIndex === 0 ? '' : '/') +
+					segment
 						.map((part) => {
 							if (part)
-								return part.dynamic
-									? '([^/]+?)'
-									: part.content
-											.normalize()
-											.replace(/\?/g, '%3F')
-											.replace(/#/g, '%23')
-											.replace(/%5B/g, '[')
-											.replace(/%5D/g, ']')
-											.replace(/[*+?^${}()|[\]\\]/g, '\\$&');
+								return part.spread
+									? '(.*?)'
+									: part.dynamic
+										? '([^/]+?)'
+										: part.content
+												.normalize()
+												.replace(/\?/g, '%3F')
+												.replace(/#/g, '%23')
+												.replace(/%5B/g, '[')
+												.replace(/%5D/g, ']')
+												.replace(/[*+?^${}()|[\]\\]/g, '\\$&');
 						})
 						.join('');
 		})
-		.join('/');
+		.join('');
 }
 
 function getReplacePattern(segments: RoutePart[][]) {

--- a/packages/vercel/src/lib/redirects.ts
+++ b/packages/vercel/src/lib/redirects.ts
@@ -48,10 +48,10 @@ function getMatchPattern(segments: RoutePart[][]) {
 		.map((segment, segmentIndex) => {
 			return segment.length === 1 && segment[0].spread
 				? '(?:\\/(.*?))?'
-                                 // Omit leading slash if segment is a spread.
-                                 // This is handled using a regex in Astro core.
-                                 // To avoid complex data massaging, we handle in-place here.
-				: (segmentIndex === 0 ? '' : '/') +
+				: // Omit leading slash if segment is a spread.
+					// This is handled using a regex in Astro core.
+					// To avoid complex data massaging, we handle in-place here.
+					(segmentIndex === 0 ? '' : '/') +
 						segment
 							.map((part) => {
 								if (part)

--- a/packages/vercel/src/lib/redirects.ts
+++ b/packages/vercel/src/lib/redirects.ts
@@ -48,6 +48,9 @@ function getMatchPattern(segments: RoutePart[][]) {
 		.map((segment, segmentIndex) => {
 			return segment.length === 1 && segment[0].spread
 				? '(?:\\/(.*?))?'
+                                 // Omit leading slash if segment is a spread.
+                                 // This is handled using a regex in Astro core.
+                                 // To avoid complex data massaging, we handle in-place here.
 				: (segmentIndex === 0 ? '' : '/') +
 						segment
 							.map((part) => {

--- a/packages/vercel/src/lib/redirects.ts
+++ b/packages/vercel/src/lib/redirects.ts
@@ -49,22 +49,22 @@ function getMatchPattern(segments: RoutePart[][]) {
 			return segment.length === 1 && segment[0].spread
 				? '(?:\\/(.*?))?'
 				: (segmentIndex === 0 ? '' : '/') +
-					segment
-						.map((part) => {
-							if (part)
-								return part.spread
-									? '(.*?)'
-									: part.dynamic
-										? '([^/]+?)'
-										: part.content
-												.normalize()
-												.replace(/\?/g, '%3F')
-												.replace(/#/g, '%23')
-												.replace(/%5B/g, '[')
-												.replace(/%5D/g, ']')
-												.replace(/[*+?^${}()|[\]\\]/g, '\\$&');
-						})
-						.join('');
+						segment
+							.map((part) => {
+								if (part)
+									return part.spread
+										? '(.*?)'
+										: part.dynamic
+											? '([^/]+?)'
+											: part.content
+													.normalize()
+													.replace(/\?/g, '%3F')
+													.replace(/#/g, '%23')
+													.replace(/%5B/g, '[')
+													.replace(/%5D/g, ']')
+													.replace(/[*+?^${}()|[\]\\]/g, '\\$&');
+							})
+							.join('');
 		})
 		.join('');
 }

--- a/packages/vercel/test/fixtures/isr/astro.config.mjs
+++ b/packages/vercel/test/fixtures/isr/astro.config.mjs
@@ -7,7 +7,7 @@ export default defineConfig({
 		isr: {
 			bypassToken: "1c9e601d-9943-4e7c-9575-005556d774a8",
 			expiration: 120,
-			exclude: ["/two", "/excluded/[dynamic]"]
+			exclude: ["/two", "/excluded/[dynamic]", "/excluded/[...rest]"]
 		}
 	})
 });

--- a/packages/vercel/test/fixtures/isr/src/pages/excluded/[...rest].astro
+++ b/packages/vercel/test/fixtures/isr/src/pages/excluded/[...rest].astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>Rest</title>
+	</head>
+	<body>
+		<h1>Rest</h1>
+	</body>
+</html>

--- a/packages/vercel/test/isr.test.js
+++ b/packages/vercel/test/isr.test.js
@@ -38,11 +38,19 @@ describe('ISR', () => {
 				dest: '_render',
 			},
 			{
+				src: '^/excluded(?:\\/(.*?))?$',
+				dest: '_render',
+			},
+			{
 				src: '^\\/_image$',
 				dest: '_render',
 			},
 			{
 				src: '^\\/excluded\\/([^/]+?)\\/?$',
+				dest: '/_isr?x_astro_path=$0',
+			},
+			{
+				src: '^\\/excluded(?:\\/(.*?))?\\/?$',
 				dest: '/_isr?x_astro_path=$0',
 			},
 			{


### PR DESCRIPTION
## Changes

The logic for generating a match pattern ([getMatchPattern](https://github.com/withastro/adapters/blob/8274001d0d1a857e633f456c5f0ff1d469d4b6e4/packages/vercel/src/lib/redirects.ts#L46)) was initially copied from the core astro repository. Since then, the implementation in Astro Core was changed a couple of times. Here is the current implementation of this function in Astro Core: https://github.com/withastro/astro/blob/cd54210/packages/astro/src/core/routing/manifest/pattern.ts#L3.

Looking into `.vercel/output/config.json`, it was found that the route generated for the excluded path contains an extra slash. Here is an example for a `"/excluded/[...rest]"` route:
```json
...
{
	"src": "^/excluded/(?:\\/(.*?))?$",
	"dest": "_render"
},
...
```
However, it should look like this:
```json
...
{
	"src": "^/excluded(?:\\/(.*?))?$",
	"dest": "_render"
},
...
```

- Changed `getMatchPattern()` so that it doesn't put a redundant slash before a route segment with rest/spread parameters.
- Changed `getMatchPattern()` so that it also works for route segments that includes the rest parameter **not** in the beginning of the segment (e.g. `/one/two[...three]`).


## Testing

Was tested by:
- Adding a modified version of the `@astro/vercel` package to the example project.
- Deploying it to Vercel and making sure that all excluded routes are not cached.
- Checking a `.vercel/output/config.json` an making sure that the route with the rest parameter is added with the `"_render"` dest and the `"src"` regex is no longer contains an extra prepending slash.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
No need to change the docs because it already mentions this case:
<img width="500" alt="docs-excluding-paths-from-caching" src="https://github.com/user-attachments/assets/331037c2-6d25-4b65-893e-fe32ab593ef2">
