### PR TITLE
fix(vercel,netlify): Prevent NFT from scanning users directory

### DIFF
--- a/.changeset/afraid-forks-joke.md
+++ b/.changeset/afraid-forks-joke.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/netlify": patch
+"@astrojs/vercel": patch
+---
+
+Prevent `@vercel/nft` from scanning users directory

--- a/packages/netlify/src/lib/nft.ts
+++ b/packages/netlify/src/lib/nft.ts
@@ -37,9 +37,9 @@ export async function copyDependenciesToFunction(
 	const { nodeFileTrace } = await import('@vercel/nft');
 	const result = await nodeFileTrace([entryPath], {
 		base: fileURLToPath(base),
-		// If you have a route of /dev this appears in source and NFT will try to
-		// scan your local /dev :8
-		ignore: ['/dev/**'],
+		// If you have a route of /dev or /users this appears in source and NFT will try to
+		// scan your local /dev or /users :8
+		ignore: ['/dev/**', '/users/**'],
 		cache,
 	});
 

--- a/packages/vercel/src/lib/nft.ts
+++ b/packages/vercel/src/lib/nft.ts
@@ -36,9 +36,9 @@ export async function copyDependenciesToFunction(
 	const { nodeFileTrace } = await import('@vercel/nft');
 	const result = await nodeFileTrace([entryPath], {
 		base: fileURLToPath(base),
-		// If you have a route of /dev this appears in source and NFT will try to
-		// scan your local /dev :8
-		ignore: ['/dev/**'],
+		// If you have a route of /dev or /users this appears in source and NFT will try to
+		// scan your local /dev or /users :8
+		ignore: ['/dev/**', '/users/**'],
 		cache,
 	});
 


### PR DESCRIPTION
## Changes

This PR adds `/users/**` to ignored directories being scanned by `@vercel/nft`. This happens when:

1. You have a `/users` string somewhere in your codebase and your app is located in `/Users/**` directory
2. You're using `pnpm` and the package/module that has that `/users` string is not added to `node_modules` because of `pnpm` symlinks
3. `@vercel/nft` thinks the `/users` string is a directory and scans it
4. Throws an error because of permissions

Here's a complete convo from discord - https://discord.com/channels/830184174198718474/1281031671495397437

## Testing

I tested it locally via `pnpm patch`, and run `pnpm build`. It works:

<img width="628" alt="Screenshot 2024-09-05 at 5 30 19 PM" src="https://github.com/user-attachments/assets/74f480b7-7bca-4c36-a139-c1cdcff08b14">


## Docs

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
