### PR TITLE
fix: allow `-` in hostnames for Netlify Image CDN

### DIFF
--- a/.changeset/orange-countries-scream.md
+++ b/.changeset/orange-countries-scream.md
@@ -2,4 +2,4 @@
 '@astrojs/netlify': patch
 ---
 
-allow `-` in hostnames for Netlify Image CDN RegEx
+Allows `-` in hostnames for Netlify Image CDN RegEx

--- a/.changeset/orange-countries-scream.md
+++ b/.changeset/orange-countries-scream.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+allow `-` in hostnames for Netlify Image CDN RegEx

--- a/packages/netlify/src/index.ts
+++ b/packages/netlify/src/index.ts
@@ -46,11 +46,11 @@ export function remotePatternToRegex(
 	if (hostname) {
 		if (hostname.startsWith('**.')) {
 			// match any number of subdomains
-			regexStr += '([a-z0-9]+\\.)*';
+			regexStr += '([a-z0-9-]+\\.)*';
 			hostname = hostname.substring(3);
 		} else if (hostname.startsWith('*.')) {
 			// match one subdomain
-			regexStr += '([a-z0-9]+\\.)?';
+			regexStr += '([a-z0-9-]+\\.)?';
 			hostname = hostname.substring(2); // Remove '*.' from the beginning
 		}
 		// Escape dots in the hostname


### PR DESCRIPTION
## Changes

Fix for: https://answers.netlify.com/t/124975/

TL;DR: The current RegEx did not match `a-us.storyblok.com` as the hostname as the RegEx only allowed lowercase letters and numbers. This PR adds `-` to the list of allowed characters.

Note that, the RegEx is not very strict. For example, as per the URL spec, the `-` should not be as the first or last character in the hostname, but this RegEx doesn't check that. It simply allows the existence of `-` in the hostname.

## Testing

There's (probably) nothing much to test here.

## Docs

N/A
