### PR TITLE
feat: update adapters supported features to account for new shape for Astro 5

### DIFF
--- a/.changeset/sweet-geckos-double.md
+++ b/.changeset/sweet-geckos-double.md
@@ -1,0 +1,8 @@
+---
+'@astrojs/cloudflare': major
+'@astrojs/netlify': major
+'@astrojs/vercel': major
+'@astrojs/node': major
+---
+
+Updates internal code for Astro 5 changes. No changes is required to your project, apart from using Astro 5

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -163,10 +163,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 						hybridOutput: 'stable',
 						staticOutput: 'unsupported',
 						i18nDomains: 'experimental',
-						assets: {
-							supportKind: 'stable',
-							isSharpCompatible: false,
-						},
+						sharpImageService: 'limited',
 						envGetSecret: 'experimental',
 					},
 				});

--- a/packages/netlify/src/index.ts
+++ b/packages/netlify/src/index.ts
@@ -455,12 +455,7 @@ export default function netlifyIntegration(
 						hybridOutput: 'stable',
 						staticOutput: 'stable',
 						serverOutput: 'stable',
-						assets: {
-							// keeping this as experimental at least until Netlify Image CDN is out of beta
-							supportKind: 'experimental',
-							// still using Netlify Image CDN instead
-							isSharpCompatible: true,
-						},
+						sharpImageService: 'stable',
 						envGetSecret: 'experimental',
 					},
 				});

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -17,10 +17,7 @@ export function getAdapter(options: Options): AstroAdapter {
 			hybridOutput: 'stable',
 			staticOutput: 'stable',
 			serverOutput: 'stable',
-			assets: {
-				supportKind: 'stable',
-				isSharpCompatible: true,
-			},
+			sharpImageService: 'stable',
 			i18nDomains: 'experimental',
 			envGetSecret: 'stable',
 		},

--- a/packages/vercel/src/serverless/adapter.ts
+++ b/packages/vercel/src/serverless/adapter.ts
@@ -90,10 +90,7 @@ function getAdapter({
 			hybridOutput: 'stable',
 			staticOutput: 'stable',
 			serverOutput: 'stable',
-			assets: {
-				supportKind: 'stable',
-				isSharpCompatible: true,
-			},
+			sharpImageService: 'stable',
 			i18nDomains: 'experimental',
 			envGetSecret: 'stable',
 		},

--- a/packages/vercel/src/static/adapter.ts
+++ b/packages/vercel/src/static/adapter.ts
@@ -23,10 +23,7 @@ function getAdapter(): AstroAdapter {
 	return {
 		name: PACKAGE_NAME,
 		supportedAstroFeatures: {
-			assets: {
-				supportKind: 'stable',
-				isSharpCompatible: true,
-			},
+			sharpImageService: 'stable',
 			staticOutput: 'stable',
 			serverOutput: 'unsupported',
 			hybridOutput: 'unsupported',


### PR DESCRIPTION
## Changes

In Astro 5, the section on assets has been removed from supportedAstroFeatures because it made no sense, you cannot not support "assets" as a concept, otherwise your adapter either can't have routes (it doesn't support having an endpoint), or does not support hosting assets in general (so you don't support any imports that results in a file, no JS, no CSS, no images etc)

In truth, adapters always support `astro:assets` the feature, what they don't support is the default image service that relies on Node API at runtime. As such, options we updated to reflect only that.

## Testing

N/A

## Docs

N/A