### PR TITLE
Reduce amount of rules in routes json file

### DIFF
--- a/.changeset/twenty-deers-wink.md
+++ b/.changeset/twenty-deers-wink.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': minor
+---
+
+Added functionality to compare include and exclude rules to reduce the amount of cloudflare rules

--- a/.changeset/weak-penguins-explode.md
+++ b/.changeset/weak-penguins-explode.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixed a bug where static file path was not split correctly

--- a/.changeset/weak-penguins-explode.md
+++ b/.changeset/weak-penguins-explode.md
@@ -1,5 +1,0 @@
----
-'@astrojs/cloudflare': patch
----
-
-Fixed a bug where static file path was not split correctly

--- a/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/env.d.ts
+++ b/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/env.d.ts
@@ -1,0 +1,2 @@
+/// <reference path="../../.astro/types.d.ts" />
+/// <reference types="astro/client" />

--- a/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/404.astro
+++ b/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/404.astro
@@ -1,0 +1,3 @@
+---
+export const prerender = true;
+---

--- a/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/dynamicPages/dynamic1.astro
+++ b/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/dynamicPages/dynamic1.astro
@@ -1,0 +1,5 @@
+---
+export const prerender=false;
+---
+
+ok

--- a/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/dynamicPages/dynamic2.astro
+++ b/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/dynamicPages/dynamic2.astro
@@ -1,0 +1,5 @@
+---
+export const prerender=false;
+---
+
+ok

--- a/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/dynamicPages/dynamic3.astro
+++ b/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/dynamicPages/dynamic3.astro
@@ -1,0 +1,5 @@
+---
+export const prerender=false;
+---
+
+ok

--- a/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/index.astro
+++ b/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/index.astro
@@ -1,0 +1,5 @@
+---
+export const prerender=false;
+---
+
+ok

--- a/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/mixedPages/dynamic.astro
+++ b/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/mixedPages/dynamic.astro
@@ -1,0 +1,5 @@
+---
+export const prerender=false;
+---
+
+ok

--- a/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/mixedPages/static.astro
+++ b/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/mixedPages/static.astro
@@ -1,0 +1,5 @@
+---
+export const prerender=true;
+---
+
+ok

--- a/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/mixedPages/subfolder/dynamic.astro
+++ b/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/mixedPages/subfolder/dynamic.astro
@@ -1,0 +1,5 @@
+---
+export const prerender=false;
+---
+
+ok

--- a/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/mixedPages/subfolder/static.astro
+++ b/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/mixedPages/subfolder/static.astro
@@ -1,0 +1,5 @@
+---
+export const prerender=true;
+---
+
+ok

--- a/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/staticPages/static1.astro
+++ b/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/staticPages/static1.astro
@@ -1,0 +1,5 @@
+---
+export const prerender=true;
+---
+
+ok

--- a/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/staticPages/static2.astro
+++ b/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/staticPages/static2.astro
@@ -1,0 +1,5 @@
+---
+export const prerender=true;
+---
+
+ok

--- a/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/staticPages/static3.astro
+++ b/packages/cloudflare/test/fixtures/routes-json/src/reduceComplexity/pages/staticPages/static3.astro
@@ -1,0 +1,5 @@
+---
+export const prerender=true;
+---
+
+ok

--- a/packages/cloudflare/test/routes-json.test.js
+++ b/packages/cloudflare/test/routes-json.test.js
@@ -48,7 +48,7 @@ describe('_routes.json generation', () => {
 			assert.deepEqual(routes, {
 				version: 1,
 				include: ['/*'],
-				exclude: ['/_astro/*', '/redirectme', '/public.txt', '/a/redirect'],
+				exclude: ['/_astro/*', '/redirectme', '/public.txt', '/a/*'],
 			});
 		});
 	});
@@ -142,6 +142,45 @@ describe('_routes.json generation', () => {
 					'/b',
 					'/another',
 					'/a/index.html',
+				],
+			});
+		});
+	});
+
+	describe('with nested on demand and prerendered routes', () => {
+		let fixture;
+
+		before(async () => {
+			fixture = await loadFixture({
+				root: new URL('./fixtures/routes-json/', import.meta.url).toString(),
+				srcDir: './src/reduceComplexity',
+				adapter: cloudflare({}),
+			});
+			await fixture.build();
+		});
+
+		it('reduces the amount of include and exclude entries by applying wildcards wherever possible', async () => {
+			const _routesJson = await fixture.readFile('/_routes.json');
+			const routes = JSON.parse(_routesJson);
+
+			assert.deepEqual(routes, {
+				version: 1,
+				include: [
+					'/',
+					'/_image',
+					'/dynamicPages/*',
+					'/mixedPages/dynamic',
+					'/mixedPages/subfolder/dynamic'
+				],
+				exclude: [
+					'/_astro/*',
+					'/redirectme',
+					'/public.txt',
+					'/a/*',
+					'/404',
+					'/mixedPages/static',
+					'/mixedPages/subfolder/static',
+					'/staticPages/*'
 				],
 			});
 		});

--- a/packages/cloudflare/test/routes-json.test.js
+++ b/packages/cloudflare/test/routes-json.test.js
@@ -170,7 +170,7 @@ describe('_routes.json generation', () => {
 					'/_image',
 					'/dynamicPages/*',
 					'/mixedPages/dynamic',
-					'/mixedPages/subfolder/dynamic'
+					'/mixedPages/subfolder/dynamic',
 				],
 				exclude: [
 					'/_astro/*',
@@ -180,7 +180,7 @@ describe('_routes.json generation', () => {
 					'/404',
 					'/mixedPages/static',
 					'/mixedPages/subfolder/static',
-					'/staticPages/*'
+					'/staticPages/*',
 				],
 			});
 		});


### PR DESCRIPTION
## Changes
Cloudflare has a limit of 100 includes/exclude rules. In many applications this amount is reached quite fast.
This PR add the functionality to compare include and exclude rules and reduce the amount of rules wherever possible.
Therefore it:
- adds a wildcard if a folder only belogs to include or exclude rules
- skips all subfolders where a wildcard is already present (leave them untouched)

## Testing

<!-- How was this change tested? -->
Tested in out own project using cloudflare as well wrote a unit test here.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
