### PR TITLE
chore: externalize `cloudflare:sockets` imports

### DIFF
--- a/.changeset/good-rivers-add.md
+++ b/.changeset/good-rivers-add.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': minor
+---
+
+Improves default config to support `cloudflare:sockets` imports

--- a/.changeset/good-rivers-add.md
+++ b/.changeset/good-rivers-add.md
@@ -1,5 +1,5 @@
 ---
-'@astrojs/cloudflare': minor
+'@astrojs/cloudflare': patch
 ---
 
-Improves default config to support `cloudflare:sockets` imports
+Fixes an issue where `cloudflare:` scoped imports made the build fail. We externalize all imports with the `cloudflare:` scope by default now.

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -129,15 +129,17 @@ export default function createIntegration(args?: Options): AstroIntegration {
 							// https://developers.cloudflare.com/pages/functions/module-support/
 							// Allows imports of '.wasm', '.bin', and '.txt' file types
 							cloudflareModulePlugin,
+							{
+								name: 'vite:cf-imports',
+								enforce: 'pre',
+								resolveId(source) {
+									if (source.startsWith("cloudflare:")) {
+										return { id: source, external: true };
+									}
+									return null;
+								},
+							}
 						],
-						ssr: {
-							external: ['cloudflare:sockets'],
-						},
-						build: {
-							rollupOptions: {
-								external: ['cloudflare:sockets'],
-							},
-						},
 					},
 					integrations: [astroWhen()],
 					image: setImageConfig(args?.imageService ?? 'compile', config.image, command, logger),

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -137,7 +137,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 							rollupOptions: {
 								external: ['cloudflare:sockets'],
 							},
-						}
+						},
 					},
 					integrations: [astroWhen()],
 					image: setImageConfig(args?.imageService ?? 'compile', config.image, command, logger),

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -130,6 +130,14 @@ export default function createIntegration(args?: Options): AstroIntegration {
 							// Allows imports of '.wasm', '.bin', and '.txt' file types
 							cloudflareModulePlugin,
 						],
+						ssr: {
+							external: ['cloudflare:sockets'],
+						},
+						build: {
+							rollupOptions: {
+								external: ['cloudflare:sockets'],
+							},
+						}
 					},
 					integrations: [astroWhen()],
 					image: setImageConfig(args?.imageService ?? 'compile', config.image, command, logger),

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -133,12 +133,12 @@ export default function createIntegration(args?: Options): AstroIntegration {
 								name: 'vite:cf-imports',
 								enforce: 'pre',
 								resolveId(source) {
-									if (source.startsWith("cloudflare:")) {
+									if (source.startsWith('cloudflare:')) {
 										return { id: source, external: true };
 									}
 									return null;
 								},
-							}
+							},
 						],
 					},
 					integrations: [astroWhen()],


### PR DESCRIPTION
**UPDATE:** I changed the approach to use a vite plugin to externalize the imports based on `resolveId`, this should be more flexible and work for all modes.

## Changes

- closes https://github.com/withastro/adapters/issues/407
- I still don't know if it would work with `astro dev`, without using `wrangler`, because in a local runtime the import wouldn't work, but at least the config wouldn't complain anymore.

## Testing

- existing tests
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

- bugfix not needed
<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
