### PR TITLE
fix(cloudflare): use React edge renderer for compatibility with React 19

### DIFF
--- a/.changeset/chatty-eels-flow.md
+++ b/.changeset/chatty-eels-flow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': minor
+---
+
+Make Cloudflare adapter compatible with React 19 (useActionState, etc.) by switching to React's edge renderer for SSR

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -219,7 +219,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					const aliases = [
 						{
 							find: 'react-dom/server',
-							replacement: 'react-dom/server.browser',
+							replacement: 'react-dom/server.edge',
 						},
 					];
 


### PR DESCRIPTION
### Note: Until a proper fix gets merged, you can use [this workaround](https://github.com/withastro/adapters/pull/436#issuecomment-2525190557).

---

React 19 requires `MessageChannel` from node:worker_threads, which isn't available in Cloudflare's workerd runtime. Switch to React's edge-optimized server renderer to avoid the MessageChannel dependency.

## More background

Trying to use `useActionState` from React 19 as described [here](https://astro.build/blog/astro-490/#react-19-support) currently results in `Uncaught ReferenceError: MessageChannel is not defined` when workerd is involved.

```
❯ rg  --no-ignore 'new MessageChannel' node_modules/react-dom/
node_modules/react-dom/cjs/react-dom-server.browser.development.js
7095:      channel = new MessageChannel(),

node_modules/react-dom/cjs/react-dom-server.browser.production.js
126:var channel = new MessageChannel(),
```

Rather than polyfilling `MessageChannel` and its dependencies, e.g. via [unenv](https://github.com/unjs/unenv), I found that switching the renderer is much easier.

The edge renderer probably makes more sense at the *edge* anyway (😄), though I don't know if the browser variant was initially chosen for a specific reason.