### PR TITLE
fix(vercel): add support for Node 22

### DIFF
--- a/.changeset/odd-kiwis-clap.md
+++ b/.changeset/odd-kiwis-clap.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': minor
+---
+
+Add support for Node 22 on Vercel serverless

--- a/packages/vercel/src/serverless/adapter.ts
+++ b/packages/vercel/src/serverless/adapter.ts
@@ -60,12 +60,14 @@ const ISR_PATH = `/_isr?${ASTRO_PATH_PARAM}=$0`;
 const SUPPORTED_NODE_VERSIONS: Record<
 	string,
 	| { status: 'default' }
+	| { status: 'available' }
 	| { status: 'beta' }
 	| { status: 'retiring'; removal: Date | string; warnDate: Date }
 	| { status: 'deprecated'; removal: Date }
 > = {
 	18: { status: 'retiring', removal: 'Early 2025', warnDate: new Date('October 1 2024') },
-	20: { status: 'default' },
+	20: { status: 'available' },
+	22: { status: 'default' },
 };
 
 function getAdapter({
@@ -572,7 +574,7 @@ function getRuntime(process: NodeJS.Process, logger: AstroIntegrationLogger): Ru
 		);
 		return 'nodejs18.x';
 	}
-	if (support.status === 'default') {
+	if (support.status === 'default' || support.status === 'available') {
 		return `nodejs${major}.x`;
 	}
 	if (support.status === 'retiring') {


### PR DESCRIPTION
## Changes

Add support for Node 22 on Vercel serverless. Fixes #446.

I'm not sure if this is the approach you'd like. If we have a `default` value for `status`, and Vercel uses the latest available version as the default, it seems we should've used whatever marked as `default` as the... default. Right now the code uses Node 18 instead, which is not what the `SUPPORTED_NODE_VERSIONS` constant suggests.

I considered making Node 22 the default, but I'm worried that it might be considered a breaking change.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

I haven't tested it yet, don't have the time to do it right now but it seems like these changes should be enough to add the support?

## Docs

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
The docs say

> The @astrojs/vercel adapter supports specific Node.js versions for deploying your Astro project on Vercel. To view the supported Node.js versions on Vercel, click on the settings tab for a project and scroll down to “Node.js Version” section.
> Check out the [Vercel documentation](https://vercel.com/docs/functions/serverless-functions/runtimes/node-js#default-and-available-versions) to learn more.

Vercel already supports Node 22 now, so the docs are currently misleading, and adding the support will correct it.