### PR TITLE
chore: update Astro peer dep for adapters

### DIFF
--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -40,7 +40,7 @@
     "wrangler": "^3.84.0"
   },
   "peerDependencies": {
-    "astro": "^5.0.0-alpha.8"
+    "astro": "^5.0.0"
   },
   "devDependencies": {
     "@astrojs/test-utils": "workspace:*",

--- a/packages/cloudflare/test/routes-json.test.js
+++ b/packages/cloudflare/test/routes-json.test.js
@@ -228,13 +228,13 @@ describe('_routes.json generation', () => {
 			await fixture.build();
 		});
 
-		it('creates `include` for on-demand and `exclude` that are supposed to match nothin', async () => {
+		it('creates `include` for on-demand and `exclude` that are supposed to match nothing', async () => {
 			const _routesJson = await fixture.readFile('/_routes.json');
 			const routes = JSON.parse(_routesJson);
 
 			assert.deepEqual(routes, {
 				version: 1,
-				include: ['/_image', '/dynamic'],
+				include: ['/dynamic', '/_image'],
 				exclude: [],
 			});
 		});

--- a/packages/netlify/package.json
+++ b/packages/netlify/package.json
@@ -36,10 +36,10 @@
     "@netlify/functions": "^2.8.0",
     "@vercel/nft": "^0.27.5",
     "esbuild": "^0.24.0",
-    "vite": "6.0.0-beta.2"
+    "vite": "6.0.0"
   },
   "peerDependencies": {
-    "astro": "^5.0.0-alpha.8"
+    "astro": "^5.0.0"
   },
   "devDependencies": {
     "@astrojs/test-utils": "workspace:*",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -30,7 +30,7 @@
     "server-destroy": "^1.0.1"
   },
   "peerDependencies": {
-    "astro": "^5.0.0-alpha.8"
+    "astro": "^5.0.0"
   },
   "devDependencies": {
     "@astrojs/test-utils": "workspace:*",

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -44,7 +44,7 @@
     "fast-glob": "^3.3.2"
   },
   "peerDependencies": {
-    "astro": "^5.0.0-alpha.8"
+    "astro": "^5.0.0"
   },
   "devDependencies": {
     "@astrojs/test-utils": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,7 +199,7 @@ importers:
         version: link:../../..
       '@astrojs/solid-js':
         specifier: ^4.4.2
-        version: 4.4.2(solid-js@1.9.3)(vite@6.0.0-beta.2(@types/node@22.8.5))
+        version: 4.4.2(solid-js@1.9.3)(vite@6.0.0(@types/node@22.8.5)(yaml@2.5.0))
       astro:
         specifier: ^5.0.0-alpha.8
         version: 5.0.0-beta.5(@types/node@22.8.5)(rollup@4.24.3)(typescript@5.6.3)
@@ -234,8 +234,8 @@ importers:
         specifier: ^0.24.0
         version: 0.24.0
       vite:
-        specifier: 6.0.0-beta.2
-        version: 6.0.0-beta.2(@types/node@20.17.4)
+        specifier: 6.0.0
+        version: 6.0.0(@types/node@20.17.4)(yaml@2.5.0)
     devDependencies:
       '@astrojs/test-utils':
         specifier: workspace:*
@@ -3681,6 +3681,9 @@ packages:
   picocolors@1.1.0:
     resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
@@ -3699,6 +3702,10 @@ packages:
 
   postcss@8.4.47:
     resolution: {integrity: sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.4.49:
+    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
   preferred-pm@4.0.0:
@@ -4343,6 +4350,46 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
+  vite@6.0.0:
+    resolution: {integrity: sha512-Q2+5yQV79EdnpbNxjD3/QHVMCBaQ3Kpd4/uL51UGuh38bIIM+s4o3FqyCzRvTRwFb+cWIUeZvaWwS9y2LD2qeQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vite@6.0.0-beta.2:
     resolution: {integrity: sha512-TdrjEhCnVNjT3kjohFhVJQL9V3SguxMAphP2RW085QbE0Xc+lRvql9l5hTIr/mttO2jhivYXEP4xfaIRPjzqiw==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -4735,10 +4782,10 @@ snapshots:
     dependencies:
       prismjs: 1.29.0
 
-  '@astrojs/solid-js@4.4.2(solid-js@1.9.3)(vite@6.0.0-beta.2(@types/node@22.8.5))':
+  '@astrojs/solid-js@4.4.2(solid-js@1.9.3)(vite@6.0.0(@types/node@22.8.5)(yaml@2.5.0))':
     dependencies:
       solid-js: 1.9.3
-      vite-plugin-solid: 2.10.2(solid-js@1.9.3)(vite@6.0.0-beta.2(@types/node@22.8.5))
+      vite-plugin-solid: 2.10.2(solid-js@1.9.3)(vite@6.0.0(@types/node@22.8.5)(yaml@2.5.0))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
       - supports-color
@@ -8158,6 +8205,8 @@ snapshots:
 
   picocolors@1.1.0: {}
 
+  picocolors@1.1.1: {}
+
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
@@ -8172,6 +8221,12 @@ snapshots:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.1.0
+      source-map-js: 1.2.1
+
+  postcss@8.4.49:
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.1.1
       source-map-js: 1.2.1
 
   preferred-pm@4.0.0:
@@ -8920,7 +8975,7 @@ snapshots:
       '@types/unist': 3.0.2
       vfile-message: 4.0.2
 
-  vite-plugin-solid@2.10.2(solid-js@1.9.3)(vite@6.0.0-beta.2(@types/node@22.8.5)):
+  vite-plugin-solid@2.10.2(solid-js@1.9.3)(vite@6.0.0(@types/node@22.8.5)(yaml@2.5.0)):
     dependencies:
       '@babel/core': 7.26.0
       '@types/babel__core': 7.20.5
@@ -8928,10 +8983,30 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.3
       solid-refresh: 0.6.3(solid-js@1.9.3)
-      vite: 6.0.0-beta.2(@types/node@22.8.5)
-      vitefu: 0.2.5(vite@6.0.0-beta.2(@types/node@22.8.5))
+      vite: 6.0.0(@types/node@22.8.5)(yaml@2.5.0)
+      vitefu: 0.2.5(vite@6.0.0(@types/node@22.8.5)(yaml@2.5.0))
     transitivePeerDependencies:
       - supports-color
+
+  vite@6.0.0(@types/node@20.17.4)(yaml@2.5.0):
+    dependencies:
+      esbuild: 0.24.0
+      postcss: 8.4.49
+      rollup: 4.24.3
+    optionalDependencies:
+      '@types/node': 20.17.4
+      fsevents: 2.3.3
+      yaml: 2.5.0
+
+  vite@6.0.0(@types/node@22.8.5)(yaml@2.5.0):
+    dependencies:
+      esbuild: 0.24.0
+      postcss: 8.4.49
+      rollup: 4.24.3
+    optionalDependencies:
+      '@types/node': 22.8.5
+      fsevents: 2.3.3
+      yaml: 2.5.0
 
   vite@6.0.0-beta.2(@types/node@18.19.62):
     dependencies:
@@ -8960,9 +9035,9 @@ snapshots:
       '@types/node': 22.8.5
       fsevents: 2.3.3
 
-  vitefu@0.2.5(vite@6.0.0-beta.2(@types/node@22.8.5)):
+  vitefu@0.2.5(vite@6.0.0(@types/node@22.8.5)(yaml@2.5.0)):
     optionalDependencies:
-      vite: 6.0.0-beta.2(@types/node@22.8.5)
+      vite: 6.0.0(@types/node@22.8.5)(yaml@2.5.0)
 
   vitefu@1.0.3(vite@6.0.0-beta.2(@types/node@18.19.62)):
     optionalDependencies:


### PR DESCRIPTION
## Changes

This PR updates **only** the peer dependency of Astro for all our adapters.

Once `5.0.0` will be published to npm, we can update also fixtures and `devDependencies`

## Testing

CI should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
