### PR TITLE
Update cloudflare-module-loader.ts

### DIFF
--- a/.changeset/quick-weeks-clap.md
+++ b/.changeset/quick-weeks-clap.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/cloudflare": patch
+---
+
+Skip replacing contents of the file if not found after cleanup

--- a/packages/cloudflare/src/utils/cloudflare-module-loader.ts
+++ b/packages/cloudflare/src/utils/cloudflare-module-loader.ts
@@ -189,7 +189,8 @@ export function cloudflareModuleLoader(
 			}
 			for (const [fileName, repls] of replacementsByFileName.entries()) {
 				const filepath = path.join(baseDir, '_worker.js', fileName);
-				if (!(await path.exists(filePath))) continue
+				const fileExists = await fs.access(filepath).then(() => true).catch(() => false)
+                		if (!(fileExists)) continue
 				const contents = await fs.readFile(filepath, 'utf-8');
 				let updated = contents;
 				for (const replacement of repls) {

--- a/packages/cloudflare/src/utils/cloudflare-module-loader.ts
+++ b/packages/cloudflare/src/utils/cloudflare-module-loader.ts
@@ -189,6 +189,7 @@ export function cloudflareModuleLoader(
 			}
 			for (const [fileName, repls] of replacementsByFileName.entries()) {
 				const filepath = path.join(baseDir, '_worker.js', fileName);
+				if (!(await fs.exists(filePath))) continue
 				const contents = await fs.readFile(filepath, 'utf-8');
 				let updated = contents;
 				for (const replacement of repls) {

--- a/packages/cloudflare/src/utils/cloudflare-module-loader.ts
+++ b/packages/cloudflare/src/utils/cloudflare-module-loader.ts
@@ -189,7 +189,7 @@ export function cloudflareModuleLoader(
 			}
 			for (const [fileName, repls] of replacementsByFileName.entries()) {
 				const filepath = path.join(baseDir, '_worker.js', fileName);
-				if (!(await fs.exists(filePath))) continue
+				if (!(await path.exists(filePath))) continue
 				const contents = await fs.readFile(filepath, 'utf-8');
 				let updated = contents;
 				for (const replacement of repls) {


### PR DESCRIPTION
## Changes

After the build happens with the cloudflare adapter, one of my applications threw error as attached. But the preview ran fine using wrangler. I then noticed then it was failing to read from a file that did not exist in the `dist/_worker.js` directory. I think this happens because the Astro cleanup happened but it had the older resultant map.

![image](https://github.com/user-attachments/assets/7197fdb6-5579-4a13-b56f-04604aeb2842)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
