### PR TITLE
Add support for `wrangler.jsonc`

### DIFF
--- a/.changeset/nine-days-grab.md
+++ b/.changeset/nine-days-grab.md
@@ -1,5 +1,5 @@
 ---
-'@astrojs/cloudflare': patch
+'@astrojs/cloudflare': minor
 ---
 
 Adds `wrangler.jsonc` to the default watched config files. If a config file is specified in `platformProxy.configPath`, that file location is watched instead of the defaults.

--- a/.changeset/nine-days-grab.md
+++ b/.changeset/nine-days-grab.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Adds `wrangler.jsonc` to the default watched config files. If a config file is specified in `platformProxy.configPath`, that file location is watched instead of the defaults.

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -130,8 +130,13 @@ export default function createIntegration(args?: Options): AstroIntegration {
 					integrations: [astroWhen()],
 					image: setImageConfig(args?.imageService ?? 'compile', config.image, command, logger),
 				});
-				addWatchFile(new URL('./wrangler.toml', config.root));
-				addWatchFile(new URL('./wrangler.json', config.root));
+				if (args?.platformProxy?.configPath) {
+					addWatchFile(new URL(args.platformProxy.configPath, config.root));
+				} else {
+					addWatchFile(new URL('./wrangler.toml', config.root));
+					addWatchFile(new URL('./wrangler.json', config.root));
+					addWatchFile(new URL('./wrangler.jsonc', config.root));
+				}
 				addMiddleware({
 					entrypoint: '@astrojs/cloudflare/entrypoints/middleware.js',
 					order: 'pre',


### PR DESCRIPTION
## Changes

`wrangler.jsonc` support was added to Wrangler [here](https://github.com/cloudflare/workers-sdk/pull/6276) (related issue: https://github.com/cloudflare/workers-sdk/issues/5437). 

- Adds `wrangler.jsonc` to watched config files
- If `configPath` is specified in `platformProxy`, that file location is watched instead of the default config file locations.

## Testing

Untested

## Docs

No docs updated; I couldn’t find docs about `wrangler.json`.