### PR TITLE
fix(actions): skip `astro actions` requests in `trailingSlash = always`

### DIFF
--- a/.changeset/purple-seas-pretend.md
+++ b/.changeset/purple-seas-pretend.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+fix for "astro actions" in "trailingSlash = always" mode

--- a/packages/node/src/serve-static.ts
+++ b/packages/node/src/serve-static.ts
@@ -8,6 +8,7 @@ import type { Options } from './types.js';
 
 // check for a dot followed by a extension made up of lowercase characters
 const isSubresourceRegex = /.+\.[a-z]+$/i;
+const isActionRegex = /^\/?_actions\/.+/;
 
 /**
  * Creates a Node.js http listener for static files and prerendered pages.
@@ -56,8 +57,11 @@ export function createStaticHandler(app: NodeApp, options: Options) {
 					}
 					break;
 				case 'always':
-					// trailing slash is not added to "subresources"
-					if (!hasSlash && !isSubresourceRegex.test(urlPath)) {
+					// biome-ignore lint/correctness/noSwitchDeclarations: <explanation>
+					const isActionRequest = isActionRegex.test(app.removeBase(urlPath)) && req.method === 'POST';
+
+					// trailing slash is not added to "subresources" and "astro actions"
+					if (!hasSlash && !isSubresourceRegex.test(urlPath) && !isActionRequest) {
 						// biome-ignore lint/style/useTemplate: <explanation>
 						pathname = urlPath + '/' + (urlQuery ? '?' + urlQuery : '');
 						res.statusCode = 301;

--- a/packages/node/src/serve-static.ts
+++ b/packages/node/src/serve-static.ts
@@ -58,7 +58,8 @@ export function createStaticHandler(app: NodeApp, options: Options) {
 					break;
 				case 'always':
 					// biome-ignore lint/correctness/noSwitchDeclarations: <explanation>
-					const isActionRequest = isActionRegex.test(app.removeBase(urlPath)) && req.method === 'POST';
+					const isActionRequest =
+						isActionRegex.test(app.removeBase(urlPath)) && req.method === 'POST';
 
 					// trailing slash is not added to "subresources" and "astro actions"
 					if (!hasSlash && !isSubresourceRegex.test(urlPath) && !isActionRequest) {

--- a/packages/node/test/fixtures/trailing-slash/src/actions/index.ts
+++ b/packages/node/test/fixtures/trailing-slash/src/actions/index.ts
@@ -1,0 +1,9 @@
+import { defineAction } from 'astro:actions';
+
+export const server = {
+    test: defineAction({
+        handler: () => {
+            return { message: 'Hello from server!' }
+        }
+    })
+}

--- a/packages/node/test/trailing-slash.test.js
+++ b/packages/node/test/trailing-slash.test.js
@@ -81,6 +81,16 @@ describe('Trailing slash', () => {
 				assert.equal(res.status, 200);
 				assert.equal(css, 'h1 { color: red; }\n');
 			});
+
+			it('Does not add trailing slash to astro actions', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/some-base/_actions/test`, {
+					method: 'POST',
+				});
+				const json = await res.json();
+
+				assert.equal(res.status, 200);
+				assert.equal(json[1], 'Hello from server!');
+			});
 		});
 		describe('Without base', async () => {
 			before(async () => {
@@ -148,6 +158,16 @@ describe('Trailing slash', () => {
 
 				assert.equal(res.status, 200);
 				assert.equal(css, 'h1 { color: red; }\n');
+			});
+
+			it('Does not add trailing slash to astro actions', async () => {
+				const res = await fetch(`http://${server.host}:${server.port}/_actions/test`, {
+					method: 'POST',
+				});
+				const json = await res.json();
+
+				assert.equal(res.status, 200);
+				assert.equal(json[1], 'Hello from server!');
 			});
 		});
 	});


### PR DESCRIPTION
## Changes
Closes [#12568](https://github.com/withastro/adapters/issues/464)



Problem: node adapter doesnt pass `astro actions` request and always redirect this to path with the `/` in the end

![image](https://github.com/user-attachments/assets/99507742-46fe-4a8c-b8df-6a8fb28c2258)
![image](https://github.com/user-attachments/assets/0a4add5e-4ca2-42c9-a96d-4f3265109413)

Solution: I just update staticHandler in case `trailing = always` to skip `astro actions` requests

## Testing

Added two test cases 

## Docs

N/A
