### PR TITLE
Add the `worker` condition to to vite config for SSR in Cloudflare Adapter

### DIFF
--- a/.changeset/spotty-snails-bake.md
+++ b/.changeset/spotty-snails-bake.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Cloudflare adaper: Use the `worker` export condition during SSR

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -126,6 +126,11 @@ export default function createIntegration(args?: Options): AstroIntegration {
 								},
 							},
 						],
+						ssr: {
+							resolve: {
+								conditions: ["worker"]
+							}
+						}
 					},
 					integrations: [astroWhen()],
 					image: setImageConfig(args?.imageService ?? 'compile', config.image, command, logger),


### PR DESCRIPTION
Fixes #461

## Changes

Adds the `worker` condition to the Cloudflare adapter for SSG.
This ensures the `worker` exports are used when available.
Solves a build issue with SSG pages when using `@astrojs/solid-js` integration

## Testing

Testing building while manualy adding 
```
vite: {
	ssr: {
		resolve: {
			conditions: ["worker"],
		},
	},
},
```


## Docs

This does not affect users, docs probably not needed?
