### PR TITLE
fix(vercel): rush monorepo support

### DIFF
--- a/.changeset/thick-donuts-warn.md
+++ b/.changeset/thick-donuts-warn.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Fixed symlink paths for node modules in Rush monorepos

--- a/packages/vercel/src/lib/searchRoot.ts
+++ b/packages/vercel/src/lib/searchRoot.ts
@@ -12,7 +12,7 @@ const ROOT_FILES = [
 	'pnpm-workspace.yaml',
 
 	// https://rushjs.io/pages/advanced/config_files/
-	// 'rush.json',
+	'rush.json',
 
 	// https://nx.dev/latest/react/getting-started/nx-setup
 	// 'workspace.json',


### PR DESCRIPTION
## Changes

This change uncomments a line used to detect the monorepo root for Rush projects. This change is necessary to include the node modules + correct symlinks as part of the Vercel build.

In a Rush monorepo with the following structure:

```
.
├── README.md
├── apps
│   ├── admin
│   ├── web
│   └── www
├── common
│   ├── changes
│   ├── config
│   ├── git-hooks
│   ├── pnpm-patches
│   ├── scripts
│   └── temp
├── package.json
├── packages
│   ├── api
│   ├── eslint-config
│   ├── shared
│   ├── test
│   ├── tsconfig
│   ├── types
│   └── ui
├── rush.json
└── tsconfig.base.json
```

Running the build process in our `apps/www` folder results in the following structure:

```
 ._render.func
├── dist
│   └── server
│       ├── _noop-middleware.mjs
│       ├── chunks
│       ├── entry.mjs
│       ├── manifest_Bl2bl94u.mjs
│       ├── pages
│       └── renderers.mjs
├── node_modules
│   ├── @radix-ui
│   │   ├── react-avatar -> ../../../../common/temp/node_modules/.pnpm/@radix-ui+react-avatar@1.1.1_@types+react-dom@18.3.1_@types+react@18.3.12_react-dom@18.3.1_react@18.3.1/node_modules/@radix-ui/react-avatar
│   │   └── react-select -> ../../../../common/temp/node_modules/.pnpm/@radix-ui+react-select@2.1.2_@types+react-dom@18.3.1_@types+react@18.3.12_react-dom@18.3.1_react@18.3.1/node_modules/@radix-ui/react-select
│   ├── clsx -> ../../../common/temp/node_modules/.pnpm/clsx@2.1.1/node_modules/clsx
│   ├── dayjs -> ../../../common/temp/node_modules/.pnpm/dayjs@1.11.6/node_modules/dayjs
│   ├── react -> ../../../common/temp/node_modules/.pnpm/react@18.3.1/node_modules/react
│   ├── react-dom -> ../../../common/temp/node_modules/.pnpm/react-dom@18.3.1_react@18.3.1/node_modules/react-dom
│   ├── sharp -> ../../../common/temp/node_modules/.pnpm/sharp@0.33.5/node_modules/sharp
│   └── tailwind-merge -> ../../../common/temp/node_modules/.pnpm/tailwind-merge@2.5.5/node_modules/tailwind-merge
├── package.json
└── src
    └── pages
        ├── [...path].astro
        ├── aboutus.astro
        ├── help.astro
        ├── index.astro
        ├── pricing.astro
        └── reviews.astro
```

Which resolves in incorrect symlinks, as well as no `node_modules` sources copied in to the `.vercel` folder.

If deployed to Vercel, it results in the following error:

<img width="1406" alt="Screenshot 2024-12-11 at 4 27 16 PM" src="https://github.com/user-attachments/assets/5aed00dd-82db-4529-b9e3-59670fd2aa4b">


After the fix, the project structure uses the monorepo root:

```
.
└── _render.func
    ├── apps
    │   └── www
    │       ├── dist
    │       │   └── server
    │       │       ├── _noop-middleware.mjs
    │       │       ├── chunks
    │       ├── node_modules
    │       │   ├── @radix-ui
    │       │   │   ├── react-avatar -> ../../../../common/temp/node_modules/.pnpm/@radix-ui+react-avatar@1.1.1_@types+react-dom@18.3.1_@types+react@18.3.12_react-dom@18.3.1_react@18.3.1/node_modules/@radix-ui/react-avatar
    │       │   │   └── react-select -> ../../../../common/temp/node_modules/.pnpm/@radix-ui+react-select@2.1.2_@types+react-dom@18.3.1_@types+react@18.3.12_react-dom@18.3.1_react@18.3.1/node_modules/@radix-ui/react-select
    │       │   ├── clsx -> ../../../common/temp/node_modules/.pnpm/clsx@2.1.1/node_modules/clsx
    │       │   ├── dayjs -> ../../../common/temp/node_modules/.pnpm/dayjs@1.11.6/node_modules/dayjs
    │       │   ├── react -> ../../../common/temp/node_modules/.pnpm/react@18.3.1/node_modules/react
    │       │   ├── react-dom -> ../../../common/temp/node_modules/.pnpm/react-dom@18.3.1_react@18.3.1/node_modules/react-dom
    │       │   ├── sharp -> ../../../common/temp/node_modules/.pnpm/sharp@0.33.5/node_modules/sharp
    │       │   └── tailwind-merge -> ../../../common/temp/node_modules/.pnpm/tailwind-merge@2.5.5/node_modules/tailwind-merge
    │       └── src
    │           └── pages
    │               ├── [...path].astro
    │               ├── aboutus.astro
    │               ├── help.astro
    │               ├── index.astro
    │               ├── pricing.astro
    │               └── reviews.astro
    ├── common
    │   └── temp
    │       └── node_modules
    │          └── .pnpm (all of our dependencies here)
    └── package.json
```


## Testing

Testing was done manually on a Vercel account. I highly doubt before this users were able to run Astro on their monorepos.

## Docs

Nothing of note