### PR TITLE
fix(netlify): don't directly assign locals

### DIFF
--- a/.changeset/great-ties-relate.md
+++ b/.changeset/great-ties-relate.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/netlify': patch
+---
+
+Fixes an error where edge middleware would incorrectly assign locals

--- a/packages/netlify/src/index.ts
+++ b/packages/netlify/src/index.ts
@@ -291,7 +291,7 @@ export default function netlifyIntegration(
 					request,
 					params: {}
 				});
-				ctx.locals = { netlify: { context } }
+				ctx.locals.netlify = { context } 
 				// https://docs.netlify.com/edge-functions/api/#return-a-rewrite
 				ctx.rewrite = (target) => {
 					if(target instanceof Request) {


### PR DESCRIPTION
## Changes

Astro 5 changes the rules to prevent middleware from reassigning locals in middleware. This broke edge middleware on Netlify, because it does that to assign the Netlify context.

## Testing

Tested locally and on Netlify

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
