### PR TITLE
fix(cloudflare): resolve conditions for svelte

### DIFF
--- a/.changeset/gorgeous-grapes-occur.md
+++ b/.changeset/gorgeous-grapes-occur.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': patch
+---
+
+Fixes a bug where svelte were not working while using the Cloudflare adapter

--- a/.changeset/gorgeous-grapes-occur.md
+++ b/.changeset/gorgeous-grapes-occur.md
@@ -2,4 +2,4 @@
 '@astrojs/cloudflare': patch
 ---
 
-Fixes a bug where svelte were not working while using the Cloudflare adapter
+Fixes a bug where Svelte was not working properly when using the Cloudflare adapter

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -12,7 +12,7 @@ import {
 import { createRedirectsFromAstroRoutes } from '@astrojs/underscore-redirects';
 import astroWhen from '@inox-tools/astro-when';
 import { AstroError } from 'astro/errors';
-import { defaultClientConditions } from 'vite';
+import { defaultServerConditions } from 'vite';
 import { type GetPlatformProxyOptions, getPlatformProxy } from 'wrangler';
 import {
 	type CloudflareModulePluginExtra,
@@ -219,11 +219,15 @@ export default function createIntegration(args?: Options): AstroIntegration {
 						}
 					}
 
-					// Support `workerd` and `worker` conditions for the ssr environment
+					// Support `workerd` and `worker` conditions for the ssr environment 
+          // while also removing the `node` condition to prevent node specific imports
 					// (previously supported in esbuild instead: https://github.com/withastro/astro/pull/7092)
 					vite.ssr ||= {};
 					vite.ssr.resolve ||= {};
-					vite.ssr.resolve.conditions ||= [...defaultClientConditions];
+					vite.ssr.resolve.conditions ||= [...defaultServerConditions];
+					vite.ssr.resolve.conditions = vite.ssr.resolve.conditions.filter(
+						(condition) => condition !== 'node'
+					);
 					vite.ssr.resolve.conditions.push('workerd', 'worker');
 
 					vite.ssr.target = 'webworker';

--- a/packages/cloudflare/test/fixtures/with-svelte/src/components/Component.svelte
+++ b/packages/cloudflare/test/fixtures/with-svelte/src/components/Component.svelte
@@ -1,1 +1,5 @@
+<script>
+  import { setContext } from 'svelte'
+  setContext('svelte', true)
+</script>
 <div class="svelte">Svelte Content</div>

--- a/packages/cloudflare/test/fixtures/with-svelte/src/components/Component.svelte
+++ b/packages/cloudflare/test/fixtures/with-svelte/src/components/Component.svelte
@@ -1,5 +1,9 @@
 <script>
-  import { setContext } from 'svelte'
-  setContext('svelte', true)
+  import { setContext, onMount } from 'svelte';
+
+  setContext('svelte', true);
+  onMount(() => {
+    console.log('The component has mounted!');
+  });
 </script>
 <div class="svelte">Svelte Content</div>


### PR DESCRIPTION
## Changes

Fixes #485.

#476 added the `workerd` and `worker` resolve conditions to fix the Vue build breaking. As this fix used the `defaultClientConditions` as a base it broke builds using Svelte. The client default conditions include the `browser` condition, which makes Svelte use the client entry when server side rendering. 

I feel that the `defaultServerConditions` make the most sense as a default here, and with filtering out the `node` condition the Vue build will still work.

## Testing

Added usage of `setContext` and `onMount` to the Cloudflare Svelte fixture. 
Without this fix the tests then fail. With the fix all tests pass.

## Docs

Should not really affect anything as this is just a bug fix.
