### PR TITLE
feat(cloudflare,netlify): stabilize astro:env secrets support

### DIFF
--- a/.changeset/brown-coats-dance.md
+++ b/.changeset/brown-coats-dance.md
@@ -1,0 +1,6 @@
+---
+'@astrojs/cloudflare': minor
+'@astrojs/netlify': minor
+---
+
+Stabilizes `astro:env` secrets support

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -166,7 +166,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
 						staticOutput: 'unsupported',
 						i18nDomains: 'experimental',
 						sharpImageService: 'limited',
-						envGetSecret: 'experimental',
+						envGetSecret: 'stable',
 					},
 				});
 			},

--- a/packages/netlify/src/index.ts
+++ b/packages/netlify/src/index.ts
@@ -482,7 +482,7 @@ export default function netlifyIntegration(
 						staticOutput: 'stable',
 						serverOutput: 'stable',
 						sharpImageService: 'stable',
-						envGetSecret: 'experimental',
+						envGetSecret: 'stable',
 					},
 				});
 			},


### PR DESCRIPTION
## Changes

- Stabilizes `astro:env` secrets support
- For cloudflare, should we mark it as `limited` since secrets must be imported within request scope?

## Testing

N/A

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
