### PR TITLE
enable static build with the vercel adapter

### DIFF
--- a/.changeset/tasty-zoos-breathe.md
+++ b/.changeset/tasty-zoos-breathe.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Fix an issue with server island caching (static build but server functions)

--- a/packages/vercel/src/index.ts
+++ b/packages/vercel/src/index.ts
@@ -72,9 +72,7 @@ function getAdapter({
 	edgeMiddleware,
 	middlewareSecret,
 	skewProtection,
-	buildOutput,
 }: {
-	buildOutput: 'server' | 'static';
 	edgeMiddleware: boolean;
 	middlewareSecret: string;
 	skewProtection: boolean;
@@ -86,7 +84,7 @@ function getAdapter({
 		args: { middlewareSecret, skewProtection },
 		adapterFeatures: {
 			edgeMiddleware,
-			buildOutput,
+			buildOutput: 'server',
 		},
 		supportedAstroFeatures: {
 			hybridOutput: 'stable',
@@ -265,7 +263,6 @@ export default function vercelAdapter({
 					}
 					setAdapter(
 						getAdapter({
-							buildOutput: _buildOutput,
 							edgeMiddleware,
 							middlewareSecret,
 							skewProtection,
@@ -277,7 +274,6 @@ export default function vercelAdapter({
 							edgeMiddleware: false,
 							middlewareSecret: '',
 							skewProtection,
-							buildOutput: _buildOutput,
 						})
 					);
 				}


### PR DESCRIPTION
## Changes
- enable running a static build with the adapter

## Testing
- running a build and getting the desired files (static p param in the fetch of a server island)

## Docs
- just a fix