### PR TITLE
fix: correctly handle wildcard hosts in preview

### DIFF
--- a/.changeset/big-islands-add.md
+++ b/.changeset/big-islands-add.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/node': patch
+---
+
+Fixes a bug that caused the preview server to ignore wildcard host options

--- a/packages/node/src/preview.ts
+++ b/packages/node/src/preview.ts
@@ -35,7 +35,13 @@ const createPreviewServer: CreatePreviewServer = async (preview) => {
 			throw err;
 		}
 	}
-	const host = preview.host ?? 'localhost';
+	// If the user didn't specify a host, it will already have been defaulted to
+	// "localhost" by getResolvedHostForHttpServer in astro core/preview/util.ts.
+	// The value `undefined` actually means that either the user set `options.server.host`
+	// to `true`, or they passed `--host` without an argument. In that case, we
+	// should listen on all IPs.
+	const host = process.env.HOST ?? preview.host ?? '0.0.0.0';
+
 	const port = preview.port ?? 4321;
 	const server = createServer(ssrHandler, host, port);
 
@@ -51,7 +57,7 @@ const createPreviewServer: CreatePreviewServer = async (preview) => {
 		});
 	}
 
-	logListeningOn(preview.logger, server.server, options);
+	logListeningOn(preview.logger, server.server, host);
 	await new Promise<void>((resolve, reject) => {
 		server.server.once('listening', resolve);
 		server.server.once('error', reject);

--- a/packages/node/src/standalone.ts
+++ b/packages/node/src/standalone.ts
@@ -24,7 +24,7 @@ export default function standalone(app: NodeApp, options: Options) {
 	const server = createServer(handler, host, port);
 	server.server.listen(port, host);
 	if (process.env.ASTRO_NODE_LOGGING !== 'disabled') {
-		logListeningOn(app.getAdapterLogger(), server.server, options);
+		logListeningOn(app.getAdapterLogger(), server.server, host);
 	}
 	return {
 		server,


### PR DESCRIPTION
## Changes

Currently the Node adapter doesn't correctly handle the `host` option in preview.

This PR updates the adapter to use the same host rules as the astro core preview server: 

- `false` or unset uses default of `localhost`
- `true` uses wildcard host (`0.0.0.0`), meaning listen on all available host interfaces
- `undefined` (only set by using the cli flag with no argument) uses wildcard
- any other value uses that as the host

Fixes https://github.com/withastro/astro/issues/13034

## Testing

Adds test suite

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
