### PR TITLE
fix(vercel): update middleware esbuild settings

### DIFF
--- a/.changeset/grumpy-phones-explode.md
+++ b/.changeset/grumpy-phones-explode.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Updates edge middleware to support es2022 syntax

--- a/.changeset/grumpy-phones-explode.md
+++ b/.changeset/grumpy-phones-explode.md
@@ -2,4 +2,4 @@
 '@astrojs/vercel': patch
 ---
 
-Updates edge middleware to support es2022 syntax
+Updates edge middleware to support esnext syntax

--- a/packages/vercel/src/serverless/middleware.ts
+++ b/packages/vercel/src/serverless/middleware.ts
@@ -42,10 +42,12 @@ export async function generateEdgeMiddleware(
 			contents: code,
 			resolveDir: fileURLToPath(root),
 		},
-		target: 'es2020',
+		target: 'es2022',
 		platform: 'browser',
+		// esbuild automatically adds the browser, import and default conditions
+		// https://esbuild.github.io/api/#conditions
 		// https://runtime-keys.proposal.wintercg.org/#edge-light
-		conditions: ['edge-light', 'worker', 'browser'],
+		conditions: ['edge-light', 'workerd', 'worker'],
 		outfile: bundledFilePath,
 		allowOverwrite: true,
 		format: 'esm',

--- a/packages/vercel/src/serverless/middleware.ts
+++ b/packages/vercel/src/serverless/middleware.ts
@@ -42,7 +42,9 @@ export async function generateEdgeMiddleware(
 			contents: code,
 			resolveDir: fileURLToPath(root),
 		},
-		target: 'es2022',
+		// Vercel Edge runtime targets ESNext, because Cloudflare Workers update v8 weekly
+		// https://github.com/vercel/vercel/blob/1006f2ae9d67ea4b3cbb1073e79d14d063d42436/packages/next/scripts/build-edge-function-template.js
+		target: 'esnext',
 		platform: 'browser',
 		// esbuild automatically adds the browser, import and default conditions
 		// https://esbuild.github.io/api/#conditions

--- a/packages/vercel/test/fixtures/middleware-with-edge-file/src/middleware.js
+++ b/packages/vercel/test/fixtures/middleware-with-edge-file/src/middleware.js
@@ -1,3 +1,7 @@
+export const hello = async () => 'hello world';
+
+const message = await hello();
+
 /**
  * @type {import("astro").MiddlewareResponseHandler}
  */
@@ -5,5 +9,6 @@ export const onRequest = async (context, next) => {
 	const test = 'something';
 	context.cookies.set('foo', 'bar');
 	const response = await next();
+	response.headers.set('x-message', message);	
 	return response;
 };


### PR DESCRIPTION
## Changes

Vercel builds its own edge functions with the esnext target, because the Cloudflare workerd runtime they use updates v8 every week.

See [comment here](https://github.com/vercel/vercel/blob/1006f2ae9d67ea4b3cbb1073e79d14d063d42436/packages/next/scripts/build-edge-function-template.js#L20)

Also updates conditions slightly so that it also includes the workerd condition. Browser doesn't need to be manually added as it's included by default

Fixes #495

## Testing

Added top level await to a edge middleware to ensure it works. It won't compile with the previous settings.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
