### PR TITLE
feat(cloudflare): add redirect routes with trailing slash

### DIFF
--- a/.changeset/curly-eels-help.md
+++ b/.changeset/curly-eels-help.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/cloudflare': minor
+---
+
+add redirect routes with trailing slash

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -71,6 +71,12 @@ export type Options = {
 	 * for reference on how these file types are exported
 	 */
 	cloudflareModules?: boolean;
+
+	/**
+	 * Duplicate redirect routes with added trailing slash. Defaults to true.
+	 * When enabled, every entry in _redirects will be duplicated with an added trailing slash.
+	 */
+	redirectAlsoWithTrailingSlash?: boolean;
 };
 
 function wrapWithSlashes(path: string): string {
@@ -345,6 +351,16 @@ export default function createIntegration(args?: Options): AstroIntegration {
 				});
 
 				if (!trueRedirects.empty()) {
+					if (args?.redirectAlsoWithTrailingSlash ?? true === true) {
+						const originalDefinitions = [...trueRedirects.definitions];
+						trueRedirects.definitions = [];
+						for (const definition of originalDefinitions) {
+							trueRedirects.definitions.push(definition);
+							trueRedirects.definitions.push({ ...definition, input: appendForwardSlash(definition.input) });
+						}
+						trueRedirects.minInputLength += 1;
+					}
+
 					try {
 						await appendFile(new URL('./_redirects', _config.outDir), trueRedirects.print());
 					} catch (error) {


### PR DESCRIPTION
## Changes

- fixes withastro/astro#13165
- duplicates every route in `_redirects` with added trailing slash to avoid 404 by default
- offers adapter configuration flag `redirectAlsoWithTrailingSlash` to disable this behaviour

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
No additional test added because there was no initial test targeting `_redirects' was found.

## Docs

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
Should be added to docs, including the `redirectAlsoWithTrailingSlash` option.
