### PR TITLE
fix: use vercel routing utils

### DIFF
--- a/.changeset/tidy-walls-check.md
+++ b/.changeset/tidy-walls-check.md
@@ -2,4 +2,4 @@
 '@astrojs/vercel': patch
 ---
 
-Handle trailing slashes correctly
+Fixes a bug that caused redirect loops when trailingSlash was set

--- a/.changeset/tidy-walls-check.md
+++ b/.changeset/tidy-walls-check.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Handle trailing slashes correctly

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -10,7 +10,10 @@
     "url": "https://github.com/withastro/adapters.git",
     "directory": "packages/vercel"
   },
-  "keywords": ["withastro", "astro-adapter"],
+  "keywords": [
+    "withastro",
+    "astro-adapter"
+  ],
   "bugs": "https://github.com/withastro/adapters/issues",
   "homepage": "https://docs.astro.build/en/guides/integrations-guide/vercel/",
   "exports": {
@@ -25,11 +28,18 @@
   },
   "typesVersions": {
     "*": {
-      "serverless": ["dist/serverless/adapter.d.ts"],
-      "static": ["dist/static/adapter.d.ts"]
+      "serverless": [
+        "dist/serverless/adapter.d.ts"
+      ],
+      "static": [
+        "dist/static/adapter.d.ts"
+      ]
     }
   },
-  "files": ["dist", "types.d.ts"],
+  "files": [
+    "dist",
+    "types.d.ts"
+  ],
   "scripts": {
     "build": "tsc",
     "test": "astro-scripts test --timeout 50000 \"test/**/!(hosted).test.js\"",
@@ -40,6 +50,7 @@
     "@vercel/analytics": "^1.4.1",
     "@vercel/edge": "^1.2.1",
     "@vercel/nft": "^0.29.0",
+    "@vercel/routing-utils": "^5.0.0",
     "esbuild": "^0.24.0",
     "fast-glob": "^3.3.3"
   },

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -10,10 +10,7 @@
     "url": "https://github.com/withastro/adapters.git",
     "directory": "packages/vercel"
   },
-  "keywords": [
-    "withastro",
-    "astro-adapter"
-  ],
+  "keywords": ["withastro", "astro-adapter"],
   "bugs": "https://github.com/withastro/adapters/issues",
   "homepage": "https://docs.astro.build/en/guides/integrations-guide/vercel/",
   "exports": {
@@ -28,18 +25,11 @@
   },
   "typesVersions": {
     "*": {
-      "serverless": [
-        "dist/serverless/adapter.d.ts"
-      ],
-      "static": [
-        "dist/static/adapter.d.ts"
-      ]
+      "serverless": ["dist/serverless/adapter.d.ts"],
+      "static": ["dist/static/adapter.d.ts"]
     }
   },
-  "files": [
-    "dist",
-    "types.d.ts"
-  ],
+  "files": ["dist", "types.d.ts"],
   "scripts": {
     "build": "tsc",
     "test": "astro-scripts test --timeout 50000 \"test/**/!(hosted).test.js\"",

--- a/packages/vercel/src/index.ts
+++ b/packages/vercel/src/index.ts
@@ -519,7 +519,7 @@ export default function vercelAdapter({
 				// https://vercel.com/docs/build-output-api/v3#build-output-configuration
 				await writeJson(destination, {
 					version: 3,
-					routes: [...(redirects ?? []), ...finalRoutes],
+					routes: normalized.routes,
 					images,
 				});
 

--- a/packages/vercel/src/index.ts
+++ b/packages/vercel/src/index.ts
@@ -11,6 +11,7 @@ import type {
 	HookParameters,
 	IntegrationResolvedRoute,
 } from 'astro';
+import { AstroError } from 'astro/errors';
 import glob from 'fast-glob';
 import {
 	type DevImageService,
@@ -26,7 +27,6 @@ import {
 	getInjectableWebAnalyticsContent,
 } from './lib/web-analytics.js';
 import { generateEdgeMiddleware } from './serverless/middleware.js';
-import { AstroError } from 'astro/errors';
 
 const PACKAGE_NAME = '@astrojs/vercel';
 

--- a/packages/vercel/src/index.ts
+++ b/packages/vercel/src/index.ts
@@ -2,6 +2,7 @@ import { cpSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { basename } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { emptyDir, removeDir, writeJson } from '@astrojs/internal-helpers/fs';
+import { type Route, getTransformedRoutes, normalizeRoutes } from '@vercel/routing-utils';
 import type {
 	AstroAdapter,
 	AstroConfig,
@@ -25,7 +26,6 @@ import {
 	getInjectableWebAnalyticsContent,
 } from './lib/web-analytics.js';
 import { generateEdgeMiddleware } from './serverless/middleware.js';
-import { getTransformedRoutes, normalizeRoutes, type Route } from '@vercel/routing-utils';
 
 const PACKAGE_NAME = '@astrojs/vercel';
 
@@ -265,7 +265,7 @@ export default function vercelAdapter({
 					if (
 						config.trailingSlash &&
 						config.trailingSlash !== 'ignore' &&
-						existsSync(vercelConfigPath) 
+						existsSync(vercelConfigPath)
 					) {
 						try {
 							const vercelConfig = JSON.parse(readFileSync(vercelConfigPath, 'utf-8'));

--- a/packages/vercel/src/lib/redirects.ts
+++ b/packages/vercel/src/lib/redirects.ts
@@ -1,6 +1,8 @@
 import nodePath from 'node:path';
-import { appendForwardSlash, removeLeadingForwardSlash } from '@astrojs/internal-helpers/path';
+import { removeLeadingForwardSlash } from '@astrojs/internal-helpers/path';
 import type { AstroConfig, IntegrationResolvedRoute, RoutePart } from 'astro';
+
+import type { Redirect } from '@vercel/routing-utils';
 
 const pathJoin = nodePath.posix.join;
 
@@ -40,10 +42,32 @@ function getParts(part: string, file: string) {
 
 	return result;
 }
+/**
+ * Convert Astro routes into Vercel path-to-regexp syntax, which are the input for getTransformedRoutes
+ */
+function getMatchPattern(segments: RoutePart[][]) {
+	return segments
+		.map((segment) => {
+			return segment
+				.map((part) => {
+					if (part.spread) {
+						// Extract parameter name from spread syntax (e.g., "...slug" -> "slug")
+						const paramName = part.content.startsWith('...') ? part.content.slice(3) : part.content;
+						return `:${paramName}*`;
+					}
+					if (part.dynamic) {
+						return `:${part.content}`;
+					}
+					return part.content;
+				})
+				.join('');
+		})
+		.join('/');
+}
 
 // Copied from /home/juanm04/dev/misc/astro/packages/astro/src/core/routing/manifest/create.ts
 // 2022-04-26
-function getMatchPattern(segments: RoutePart[][]) {
+function getMatchRegex(segments: RoutePart[][]) {
 	return segments
 		.map((segment, segmentIndex) => {
 			return segment.length === 1 && segment[0].spread
@@ -72,37 +96,17 @@ function getMatchPattern(segments: RoutePart[][]) {
 		.join('');
 }
 
-function getReplacePattern(segments: RoutePart[][]) {
-	let n = 0;
-	let result = '';
-
-	for (const segment of segments) {
-		for (const part of segment) {
-			// biome-ignore lint/style/useTemplate: <explanation>
-			if (part.dynamic) result += '$' + ++n;
-			else result += part.content;
-		}
-		result += '/';
-	}
-
-	// Remove trailing slash
-	result = result.slice(0, -1);
-
-	return result;
-}
 
 function getRedirectLocation(route: IntegrationResolvedRoute, config: AstroConfig): string {
 	if (route.redirectRoute) {
-		const pattern = getReplacePattern(route.redirectRoute.segments);
-		const path = config.trailingSlash === 'always' ? appendForwardSlash(pattern) : pattern;
-		return pathJoin(config.base, path);
-		// biome-ignore lint/style/noUselessElse: <explanation>
-	} else if (typeof route.redirect === 'object') {
-		return pathJoin(config.base, route.redirect.destination);
-		// biome-ignore lint/style/noUselessElse: <explanation>
-	} else {
-		return pathJoin(config.base, route.redirect || '');
+		const pattern = getMatchPattern(route.redirectRoute.segments);
+		return pathJoin(config.base, pattern);
 	}
+
+	if (typeof route.redirect === 'object') {
+		return pathJoin(config.base, route.redirect.destination);
+	}
+	return pathJoin(config.base, route.redirect || '');
 }
 
 function getRedirectStatus(route: IntegrationResolvedRoute): number {
@@ -119,40 +123,23 @@ export function escapeRegex(content: string) {
 		.map((s: string) => {
 			return getParts(s, content);
 		});
-	return `^/${getMatchPattern(segments)}$`;
+	return `^/${getMatchRegex(segments)}$`;
 }
 
 export function getRedirects(
 	routes: IntegrationResolvedRoute[],
 	config: AstroConfig
-): VercelRoute[] {
-	const redirects: VercelRoute[] = [];
+): Redirect[] {
+	const redirects: Redirect[] = [];
 
 	for (const route of routes) {
 		if (route.type === 'redirect') {
 			redirects.push({
-				src: config.base + getMatchPattern(route.segments),
-				headers: { Location: getRedirectLocation(route, config) },
-				status: getRedirectStatus(route),
+				source: config.base + getMatchPattern(route.segments),
+				destination: getRedirectLocation(route, config),
+				statusCode: getRedirectStatus(route),
 			});
-		} else if (route.type === 'page' && route.pattern !== '/') {
-			if (config.trailingSlash === 'always') {
-				redirects.push({
-					src: config.base + getMatchPattern(route.segments),
-					// biome-ignore lint/style/useTemplate: <explanation>
-					headers: { Location: config.base + getReplacePattern(route.segments) + '/' },
-					status: 308,
-				});
-			} else if (config.trailingSlash === 'never') {
-				redirects.push({
-					// biome-ignore lint/style/useTemplate: <explanation>
-					src: config.base + getMatchPattern(route.segments) + '/',
-					headers: { Location: config.base + getReplacePattern(route.segments) },
-					status: 308,
-				});
-			}
 		}
 	}
-
 	return redirects;
-}
+};

--- a/packages/vercel/src/lib/redirects.ts
+++ b/packages/vercel/src/lib/redirects.ts
@@ -96,7 +96,6 @@ function getMatchRegex(segments: RoutePart[][]) {
 		.join('');
 }
 
-
 function getRedirectLocation(route: IntegrationResolvedRoute, config: AstroConfig): string {
 	if (route.redirectRoute) {
 		const pattern = getMatchPattern(route.redirectRoute.segments);
@@ -126,10 +125,7 @@ export function escapeRegex(content: string) {
 	return `^/${getMatchRegex(segments)}$`;
 }
 
-export function getRedirects(
-	routes: IntegrationResolvedRoute[],
-	config: AstroConfig
-): Redirect[] {
+export function getRedirects(routes: IntegrationResolvedRoute[], config: AstroConfig): Redirect[] {
 	const redirects: Redirect[] = [];
 
 	for (const route of routes) {
@@ -142,4 +138,4 @@ export function getRedirects(
 		}
 	}
 	return redirects;
-};
+}

--- a/packages/vercel/test/isr.test.js
+++ b/packages/vercel/test/isr.test.js
@@ -38,31 +38,31 @@ describe('ISR', () => {
 				dest: '_render',
 			},
 			{
-				src: '^/excluded(?:\\/(.*?))?$',
+				src: '^/excluded(?:/(.*?))?$',
 				dest: '_render',
 			},
 			{
-				src: '^\\/_server-islands\\/([^/]+?)\\/?$',
+				src: '^/_server-islands/([^/]+?)/?$',
 				dest: '_render',
 			},
 			{
-				src: '^\\/_image\\/?$',
+				src: '^/_image/?$',
 				dest: '_render',
 			},
 			{
-				src: '^\\/excluded\\/([^/]+?)\\/?$',
+				src: '^/excluded/([^/]+?)/?$',
 				dest: '/_isr?x_astro_path=$0',
 			},
 			{
-				src: '^\\/excluded(?:\\/(.*?))?\\/?$',
+				src: '^/excluded(?:/(.*?))?/?$',
 				dest: '/_isr?x_astro_path=$0',
 			},
 			{
-				src: '^\\/one\\/?$',
+				src: '^/one/?$',
 				dest: '/_isr?x_astro_path=$0',
 			},
 			{
-				src: '^\\/two\\/?$',
+				src: '^/two/?$',
 				dest: '/_isr?x_astro_path=$0',
 			},
 		]);

--- a/packages/vercel/test/prerendered-error-pages.test.js
+++ b/packages/vercel/test/prerendered-error-pages.test.js
@@ -18,7 +18,7 @@ describe('prerendered error pages routing', () => {
 		assert.deepEqual(
 			deploymentConfig.routes.find((r) => r.status === 404),
 			{
-				src: '/.*',
+				src: '^/.*$',
 				dest: '/404.html',
 				status: 404,
 			}

--- a/packages/vercel/test/redirects.test.js
+++ b/packages/vercel/test/redirects.test.js
@@ -27,22 +27,20 @@ describe('Redirects', () => {
 	async function getConfig() {
 		const json = await fixture.readFile('../.vercel/output/config.json');
 		const config = JSON.parse(json);
-
 		return config;
 	}
 
 	it('define static routes', async () => {
 		const config = await getConfig();
-
-		const oneRoute = config.routes.find((r) => r.src === '/one');
+		const oneRoute = config.routes.find((r) => r.src === '^/one$');
 		assert.equal(oneRoute.headers.Location, '/');
 		assert.equal(oneRoute.status, 301);
 
-		const twoRoute = config.routes.find((r) => r.src === '/two');
+		const twoRoute = config.routes.find((r) => r.src === '^/two$');
 		assert.equal(twoRoute.headers.Location, '/');
 		assert.equal(twoRoute.status, 301);
 
-		const threeRoute = config.routes.find((r) => r.src === '/three');
+		const threeRoute = config.routes.find((r) => r.src === '^/three$');
 		assert.equal(threeRoute.headers.Location, '/');
 		assert.equal(threeRoute.status, 302);
 	});
@@ -50,7 +48,7 @@ describe('Redirects', () => {
 	it('define redirects for static files', async () => {
 		const config = await getConfig();
 
-		const staticRoute = config.routes.find((r) => r.src === '/Basic/http-2-0.html');
+		const staticRoute = config.routes.find((r) => r.src === '^/Basic/http-2-0\\.html$');
 		assert.notEqual(staticRoute, undefined);
 		assert.equal(staticRoute.headers.Location, '/posts/http2');
 		assert.equal(staticRoute.status, 301);
@@ -59,25 +57,10 @@ describe('Redirects', () => {
 	it('defines dynamic routes', async () => {
 		const config = await getConfig();
 
-		const blogRoute = config.routes.find((r) => r.src.startsWith('/blog'));
+		const blogRoute = config.routes.find((r) => r.src.startsWith('^/blog'));
 		assert.notEqual(blogRoute, undefined);
 		assert.equal(blogRoute.headers.Location.startsWith('/team/articles'), true);
 		assert.equal(blogRoute.status, 301);
 	});
 
-	it('define trailingSlash redirect for sub pages', async () => {
-		const config = await getConfig();
-
-		const subpathRoute = config.routes.find((r) => r.src === '/subpage');
-		assert.notEqual(subpathRoute, undefined);
-		assert.equal(subpathRoute.headers.Location, '/subpage/');
-	});
-
-	it('does not define trailingSlash redirect for root page', async () => {
-		const config = await getConfig();
-		assert.equal(
-			config.routes.find((r) => r.src === '/'),
-			undefined
-		);
-	});
 });

--- a/packages/vercel/test/redirects.test.js
+++ b/packages/vercel/test/redirects.test.js
@@ -62,4 +62,19 @@ describe('Redirects', () => {
 		assert.equal(blogRoute.headers.Location.startsWith('/team/articles'), true);
 		assert.equal(blogRoute.status, 301);
 	});
+
+	it('throws an error for invalid redirects', async () => {
+		const fails = await loadFixture({
+			root: './fixtures/redirects/',
+			redirects: {
+				// Invalid source syntax
+				'/blog/(![...slug]': '/team/articles/[...slug]',
+			},
+		});
+		await assert.rejects(() => fails.build(), {
+			name: 'AstroUserError',
+			message:
+				'Error generating redirects: Redirect at index 0 has invalid `source` regular expression "/blog/(!:slug*".',
+		});
+	});
 });

--- a/packages/vercel/test/redirects.test.js
+++ b/packages/vercel/test/redirects.test.js
@@ -62,5 +62,4 @@ describe('Redirects', () => {
 		assert.equal(blogRoute.headers.Location.startsWith('/team/articles'), true);
 		assert.equal(blogRoute.status, 301);
 	});
-
 });

--- a/packages/vercel/test/static.test.js
+++ b/packages/vercel/test/static.test.js
@@ -17,7 +17,7 @@ describe('static routing', () => {
 		const deploymentConfig = JSON.parse(await fixture.readFile('../.vercel/output/config.json'));
 		// change the index if necesseary
 		assert.deepEqual(deploymentConfig.routes[2], {
-			src: '/.*',
+			src: '^/.*$',
 			dest: '/404.html',
 			status: 404,
 		});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,6 +529,9 @@ importers:
       '@vercel/nft':
         specifier: ^0.29.0
         version: 0.29.0(rollup@4.30.1)
+      '@vercel/routing-utils':
+        specifier: ^5.0.0
+        version: 5.0.0
       esbuild:
         specifier: ^0.24.0
         version: 0.24.2
@@ -2470,6 +2473,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@vercel/routing-utils@5.0.0':
+    resolution: {integrity: sha512-llvozDbkGDSelbgigAt9IwCQS8boP4rNHfy3rpJf0DqSn6UDlkFX270NwIQruyXN9KHktHC9qOof6Ik2+bT88A==}
+
   '@vitejs/plugin-vue-jsx@4.1.1':
     resolution: {integrity: sha512-uMJqv/7u1zz/9NbWAD3XdjaY20tKTf17XVfQ9zq4wY1BjsB/PjpJPMe2xiG39QpP4ZdhYNhm4Hvo66uJrykNLA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -4207,6 +4213,9 @@ packages:
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
+
+  path-to-regexp@6.1.0:
+    resolution: {integrity: sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -7529,6 +7538,12 @@ snapshots:
       - rollup
       - supports-color
 
+  '@vercel/routing-utils@5.0.0':
+    dependencies:
+      path-to-regexp: 6.1.0
+    optionalDependencies:
+      ajv: 6.12.6
+
   '@vitejs/plugin-vue-jsx@4.1.1(vite@6.0.7(@types/node@22.10.6)(yaml@2.6.1))(vue@3.5.13(typescript@5.7.3))':
     dependencies:
       '@babel/core': 7.26.0
@@ -9709,6 +9724,8 @@ snapshots:
       minipass: 7.1.2
 
   path-to-regexp@0.1.12: {}
+
+  path-to-regexp@6.1.0: {}
 
   path-to-regexp@6.3.0: {}
 


### PR DESCRIPTION
## Changes

This updates the Vercel adapter to use the [`@vercel/routing-utils`](https://www.npmjs.com/package/@vercel/routing-utils) to generate redirect routes, rather than building them ourselves. Instead we generate the redirects in the hgher-level path-to-regexp syntax, which we then pass to `getTransformedRoutes`. This has the benefit of automatically handling trailing slash redirects and various Vercel edge cases.

We also now validate and normalise the generated routes using `normalizeRoutes`.

This also adds an error message for conflicting config if the user has conflicting `trailingSlash` set in the Vercel config. There is no reason to use it in the `vercel.json` now, because the adapter does the same thing.

Fixes #418 
Fix #499 

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
