### PR TITLE
fix: pin `@vercel/routing-utils`

### DIFF
--- a/.changeset/angry-fireants-stare.md
+++ b/.changeset/angry-fireants-stare.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/vercel': patch
+---
+
+Pins `@vercel/routing-utils` to avoid broken version

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -40,7 +40,7 @@
     "@vercel/analytics": "^1.4.1",
     "@vercel/edge": "^1.2.1",
     "@vercel/nft": "^0.29.0",
-    "@vercel/routing-utils": "^5.0.0",
+    "@vercel/routing-utils": "5.0.2",
     "esbuild": "^0.24.0",
     "fast-glob": "^3.3.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -530,8 +530,8 @@ importers:
         specifier: ^0.29.0
         version: 0.29.0(rollup@4.30.1)
       '@vercel/routing-utils':
-        specifier: ^5.0.0
-        version: 5.0.0
+        specifier: 5.0.2
+        version: 5.0.2
       esbuild:
         specifier: ^0.24.0
         version: 0.24.2
@@ -2473,8 +2473,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@vercel/routing-utils@5.0.0':
-    resolution: {integrity: sha512-llvozDbkGDSelbgigAt9IwCQS8boP4rNHfy3rpJf0DqSn6UDlkFX270NwIQruyXN9KHktHC9qOof6Ik2+bT88A==}
+  '@vercel/routing-utils@5.0.2':
+    resolution: {integrity: sha512-uJViB3+HEo+kzHYELs7cQWX5k0kCNvq9G/8nJQX8mP5Ta0fG68CBRmOaaG8A+2xbtTp/QuGORIwV8CsI9ebcNg==}
 
   '@vitejs/plugin-vue-jsx@4.1.1':
     resolution: {integrity: sha512-uMJqv/7u1zz/9NbWAD3XdjaY20tKTf17XVfQ9zq4wY1BjsB/PjpJPMe2xiG39QpP4ZdhYNhm4Hvo66uJrykNLA==}
@@ -7538,9 +7538,10 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/routing-utils@5.0.0':
+  '@vercel/routing-utils@5.0.2':
     dependencies:
       path-to-regexp: 6.1.0
+      path-to-regexp-updated: path-to-regexp@6.3.0
     optionalDependencies:
       ajv: 6.12.6
 


### PR DESCRIPTION
## Changes

Pins version of Vercel routing utils because of https://github.com/vercel/vercel/issues/13024

## Testing
Tests should now pass
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update README.md! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
